### PR TITLE
[codex] Add installable Loop Library skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,14 @@
   contributor attribution, published and modified dates, practical context,
   verification criteria, and related-loop links.
 - After changing the catalog or homepage rows, run
+  `node scripts/build-skill-catalog.mjs` and
   `node scripts/build-loop-pages.mjs`, capture the versioned page screenshots,
-  and then run `node scripts/build-social-images.mjs`. Commit the screenshots,
-  generated detail pages, `site/sitemap.xml`, and `site/feed.xml`.
+  and then run `node scripts/build-social-images.mjs`. Commit the skill catalog,
+  screenshots, generated detail pages, `site/sitemap.xml`, and `site/feed.xml`.
 - Run the full repository checks before committing:
 
   ```bash
+  node scripts/build-skill-catalog.mjs
   node scripts/build-loop-pages.mjs
   node scripts/build-social-images.mjs
   node --check scripts/build-social-images.mjs
@@ -29,8 +31,9 @@
   git diff --check
   ```
 
-- Do not add a loop if the checks report drift between the homepage, catalog,
-  generated pages, structured data, sitemap, or feed.
+- Do not add a loop if the checks report drift between the homepage, source
+  catalog, installable skill catalog, generated pages, structured data,
+  sitemap, or feed.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 A Forward Future microsite collecting useful agentic engineering loops.
 
+## Install the agent skill
+
+Install the Loop Library skill globally with the open agent-skills CLI. It can
+recommend published loops, adapt one to your situation, or interview you and
+turn an outcome into a bounded, copy-ready loop.
+
+```bash
+npx skills add mberman84/loop-library --skill loop-library -g
+```
+
+Once installed, ask your coding agent to find a loop for a problem or help you
+design one. For example: `Help me design a loop that turns customer feedback
+into verified fixes.`
+
 ## Local preview
 
 ```bash
@@ -14,6 +28,7 @@ Then open `http://localhost:4173`.
 
 ```bash
 npm --prefix worker install
+node scripts/build-skill-catalog.mjs
 node scripts/build-loop-pages.mjs
 node scripts/build-social-images.mjs
 node --check scripts/build-social-images.mjs
@@ -33,14 +48,17 @@ When adding or editing a loop:
 1. Update the table row and visible count in `site/index.html`.
 2. Update the matching entry and social-image version in
    `scripts/loop-data.mjs`.
-3. Run `node scripts/build-loop-pages.mjs` so every page reflects the catalog.
-4. Capture 1200 × 630 light-theme screenshots of the homepage and each loop
+3. Run `node scripts/build-skill-catalog.mjs` so the installable skill can find
+   every published loop offline.
+4. Run `node scripts/build-loop-pages.mjs` so every page reflects the catalog.
+5. Capture 1200 × 630 light-theme screenshots of the homepage and each loop
    page using the versioned filenames in `site/assets/social/`.
-5. Run `node scripts/build-social-images.mjs`.
-6. Run the checks above.
+6. Run `node scripts/build-social-images.mjs`.
+7. Run the checks above.
 
 The generator writes:
 
+- `skills/loop-library/references/catalog.md`
 - `site/assets/social/*.<png|jpg>`
 - `site/loops/<slug>/index.html`
 - `site/sitemap.xml`

--- a/scripts/build-skill-catalog.mjs
+++ b/scripts/build-skill-catalog.mjs
@@ -1,0 +1,55 @@
+import { writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { getLoopCategory, loops, site } from "./loop-data.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const catalogPath = path.join(
+  root,
+  "skills",
+  "loop-library",
+  "references",
+  "catalog.md",
+);
+
+export function renderSkillCatalog() {
+  const titleBySlug = new Map(loops.map((loop) => [loop.slug, loop.title]));
+  const lines = [
+    "# Published Loop Library catalog",
+    "",
+    `Snapshot generated from \`scripts/loop-data.mjs\` (catalog updated ${site.updated}).`,
+    `Canonical catalog: ${site.baseUrl}`,
+    "",
+    "Search by outcome, trigger, artifact, evidence, category, or keyword. Check",
+    "the canonical catalog when freshness matters. Treat adaptations and new designs",
+    "as unpublished unless they appear at the canonical URL.",
+    "",
+  ];
+
+  for (const loop of loops) {
+    const url = `${site.baseUrl}loops/${loop.slug}/`;
+    const related = loop.related
+      .map((slug) => `[${titleBySlug.get(slug)}](${site.baseUrl}loops/${slug}/)`)
+      .join(", ");
+
+    lines.push(
+      `## ${loop.number} — [${loop.title}](${url})`,
+      "",
+      `- Category: ${getLoopCategory(loop).label}`,
+      `- Use when: ${loop.useWhen}`,
+      `- Prompt: ${loop.prompt}`,
+      `- Verify: ${loop.verifyTitle} ${loop.verifyDetail}`,
+      `- Keywords: ${loop.keywords.join(", ")}`,
+      `- Related: ${related}`,
+      "",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await writeFile(catalogPath, renderSkillCatalog(), "utf8");
+  console.log(`Wrote ${path.relative(root, catalogPath)} from ${loops.length} loops.`);
+}

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -10,10 +10,12 @@ import {
   loops,
   site as siteMeta,
 } from "./loop-data.mjs";
+import { renderSkillCatalog } from "./build-skill-catalog.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const siteRoot = path.join(root, "site");
 const workerRoot = path.join(root, "worker");
+const skillRoot = path.join(root, "skills", "loop-library");
 
 const [
   html,
@@ -27,6 +29,9 @@ const [
   hereNowIcon,
   loopDirectories,
   loopPages,
+  skillSource,
+  skillCatalog,
+  skillInterface,
 ] =
   await Promise.all([
     readFile(path.join(siteRoot, "index.html"), "utf8"),
@@ -47,7 +52,10 @@ const [
         ),
       ),
     ),
-]);
+    readFile(path.join(skillRoot, "SKILL.md"), "utf8"),
+    readFile(path.join(skillRoot, "references", "catalog.md"), "utf8"),
+    readFile(path.join(skillRoot, "agents", "openai.yaml"), "utf8"),
+  ]);
 
 const dataManifest = JSON.parse(dataSource);
 const wranglerConfig = JSON.parse(wranglerSource);
@@ -149,6 +157,12 @@ assert(loops.every((loop) => !Object.hasOwn(loop, "type")));
 assert(loops.every((loop) => !Object.hasOwn(loop, "typeSlug")));
 assert(requestedConceptSlugs.every((slug) => slugs.has(slug)));
 assert.deepEqual(loopDirectories.sort(), [...slugs].sort());
+assert.equal(skillCatalog, renderSkillCatalog());
+assert(skillSource.startsWith("---\nname: loop-library\ndescription:"));
+assert(skillSource.includes("## Run the design interview"));
+assert(skillSource.includes("## Deliver the loop"));
+assert(skillInterface.includes('display_name: "Loop Library"'));
+assert(skillInterface.includes("$loop-library"));
 
 for (const [index, loop] of loops.entries()) {
   const url = `${siteMeta.baseUrl}loops/${loop.slug}/`;

--- a/skills/loop-library/SKILL.md
+++ b/skills/loop-library/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: loop-library
+description: Find, compare, adapt, and design repeatable AI-agent loops with explicit triggers, actions, verification, stopping conditions, guardrails, and handoffs. Use when a user asks for a loop, recurring agent workflow, automation cadence, iterative improvement process, an existing Loop Library recommendation, or help turning an outcome into a bounded copy-ready loop through a short question-led design session.
+---
+
+# Loop Library
+
+Help the user reuse a published Forward Future loop when one fits. Otherwise,
+adapt the closest loop or design a new one through a focused interview. Treat a
+loop as a feedback system with terminal states, not as permission for endless
+autonomy.
+
+## Route the request
+
+Choose the smallest useful path:
+
+- **Find:** Recommend one to three published loops for a stated problem.
+- **Adapt:** Start from a published loop and replace its thresholds, tools,
+  cadence, owners, or checks without weakening its feedback cycle.
+- **Design:** Interview the user, then produce a new bounded loop.
+- **Find, then design:** Search first. Use the nearest published loop as a
+  scaffold and ask only about the missing decisions.
+
+Do not ask for information the user already supplied. If the request is vague,
+begin with: "What outcome should this loop reliably produce?"
+
+## Find a published loop
+
+1. Read [references/catalog.md](references/catalog.md). Search its `Use when`,
+   `Prompt`, `Verify`, and keyword fields by the user's outcome, trigger,
+   artifact, risk, and evidence—not only by title.
+2. If the user asks for the latest catalog, or freshness materially affects the
+   answer and web access is available, check the canonical
+   [Loop Library](https://signals.forwardfuture.ai/loop-library/) before
+   recommending.
+3. Rank candidates by outcome fit, available inputs and tools, verification
+   fit, acceptable authority, and stopping condition.
+4. Recommend at most three. For each, give its exact published title and link,
+   why it fits, and the smallest adaptation required.
+5. Prefer adapting a strong match over inventing a nearly identical loop. If no
+   loop fits, say so plainly and switch to the design interview.
+
+Never invent a Loop Library title, number, contributor, or URL. Label an
+adaptation or new design as such; do not imply that it is already published.
+
+## Run the design interview
+
+Ask one focused question at a time by default. Group no more than three when the
+user asks for a faster intake. Explain a tradeoff only when it affects the
+answer. Cover only unresolved items:
+
+1. **Outcome:** What observable result should the loop produce, and for whom?
+2. **Start signal:** What triggers it—an event, schedule, threshold, manual
+   request, or failed check?
+3. **Scope and inputs:** What systems, evidence, files, data, and tools may it
+   inspect? What may it change?
+4. **Cycle:** What is the smallest useful action, and what feedback should
+   determine the next action?
+5. **Success gate:** What reproducible evidence proves the result is good
+   enough?
+6. **Terminal states:** When should it succeed, stop with no changes, request
+   approval, report a blocker, or stop after budget or progress is exhausted?
+7. **Safety:** What actions are forbidden, destructive, expensive, sensitive,
+   customer-facing, or approval-gated?
+8. **State and handoff:** What should persist between cycles, and what artifact
+   or report should the loop leave behind?
+
+Offer a reasonable default when the user does not know an answer, then ask them
+to confirm it. Stop interviewing once the remaining details would not change
+the design materially.
+
+## Design the feedback cycle
+
+Build every loop around this sequence:
+
+1. **Observe:** Read fresh state and collect the agreed evidence.
+2. **Choose:** Select the highest-value in-scope action from explicit criteria.
+3. **Act:** Make one bounded, reversible change or produce one candidate.
+4. **Verify:** Run the same acceptance check under recorded conditions.
+5. **Record:** Save the action, evidence, outcome, and remaining work.
+6. **Repeat or stop:** Continue only while progress is measurable and budget
+   remains; otherwise enter a named terminal state.
+
+Apply these rules:
+
+- Make the success gate observable and reproducible. Replace "until happy"
+  with a rubric, threshold, benchmark, reviewer decision, or finite scenario
+  set whenever possible.
+- Define success, clean no-op, blocked, approval-required, exhausted, and
+  stagnated outcomes where relevant. Never report an error or exhausted budget
+  as success.
+- Bound time, iterations, cost, retries, or affected scope. Add an escalation
+  owner for important blocked work.
+- Re-read current state before consequential actions. Do not ship stale code,
+  partial artifacts, or assumptions carried from an earlier cycle.
+- Preserve unrelated user work. Require explicit approval for destructive,
+  irreversible, production, financial, privacy-sensitive, or external-message
+  actions.
+- Separate the working signal from a fresh acceptance gate when optimizing a
+  prompt, model, ranking, or other artifact that could overfit its own metric.
+- Use independent verification when the same actor should not both create and
+  approve high-impact output.
+- Recommend a one-shot workflow instead of manufacturing a loop when no new
+  feedback can change the next action.
+
+Designing a loop does not authorize enabling a schedule, changing production,
+or sending external messages. Implement or activate it only when the user asks.
+
+## Deliver the loop
+
+Return a concise design in this order:
+
+```markdown
+## [Loop name]
+
+Purpose: [observable outcome]
+Use when: [fit and prerequisites]
+Trigger: [event, schedule, threshold, or manual start]
+Inputs and authority: [evidence, tools, allowed reads and writes]
+Persistent state: [what survives between cycles]
+
+Cycle:
+1. Observe ...
+2. Choose ...
+3. Act ...
+4. Verify ...
+5. Record ...
+6. Repeat or stop ...
+
+Success gate: [reproducible proof]
+Other terminal states: [no-op, approval, blocker, exhaustion, stagnation]
+Guardrails: [forbidden and approval-gated actions]
+Budget and escalation: [limits, retries, owner]
+Finish with: [artifact or handoff]
+
+Copy-ready prompt:
+> [self-contained agent instruction]
+```
+
+Write the copy-ready prompt so it can stand alone. Use this compact pattern:
+
+> When [trigger], inspect [fresh inputs]. Choose [bounded action] using
+> [criteria], then [act]. After each action, verify [evidence] under [conditions]
+> and record [state]. Repeat only while [progress rule] and [budget] allow. Stop
+> successfully when [gate]. Stop without changes when [no-op]. Request approval
+> or escalate when [condition]. Never [guardrail]. Finish with [artifact].
+
+End with any assumptions that still need confirmation and one or two related
+published loops when they offer useful patterns.

--- a/skills/loop-library/agents/openai.yaml
+++ b/skills/loop-library/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Loop Library"
+  short_description: "Find and design reliable agent loops"
+  default_prompt: "Use $loop-library to find an existing agent loop or help me design one for my goal."

--- a/skills/loop-library/references/catalog.md
+++ b/skills/loop-library/references/catalog.md
@@ -1,0 +1,242 @@
+# Published Loop Library catalog
+
+Snapshot generated from `scripts/loop-data.mjs` (catalog updated 2026-06-18).
+Canonical catalog: https://signals.forwardfuture.ai/loop-library/
+
+Search by outcome, trigger, artifact, evidence, category, or keyword. Check
+the canonical catalog when freshness matters. Treat adaptations and new designs
+as unpublished unless they appear at the canonical URL.
+
+## 001 — [The docs sweep](https://signals.forwardfuture.ai/loop-library/loops/overnight-docs-sweep/)
+
+- Category: Engineering
+- Use when: Use this whenever implementation changes may have left READMEs, setup guides, API references, examples, or runbooks behind.
+- Prompt: Whenever a documentation pass is needed, review the codebase in full and make sure all documentation reflects the current implementation. Update stale documentation, verify the changes, then open a pull request.
+- Verify: Documentation matches the current implementation. Finish with a reviewable pull request.
+- Keywords: AI coding agent, documentation audit, documentation drift, documentation maintenance, pull request workflow
+- Related: [The production error sweep](https://signals.forwardfuture.ai/loop-library/loops/production-error-sweep/), [The architecture satisfaction loop](https://signals.forwardfuture.ai/loop-library/loops/architecture-satisfaction-loop/)
+
+## 002 — [The architecture satisfaction loop](https://signals.forwardfuture.ai/loop-library/loops/architecture-satisfaction-loop/)
+
+- Category: Engineering
+- Use when: Use this for a deliberate architectural refactor where the destination can be stated in concrete terms and the current system can be tested after each meaningful change.
+- Prompt: Refactor until you are happy with the architecture. After each significant step, live-test the system, run autoreview, and commit. Track progress in /tmp/refactor-{projectname}.md.
+- Verify: The architecture is satisfactory and checks pass. Live-test, autoreview, and commit each significant step.
+- Keywords: AI coding agent, architecture refactor, autoreview, incremental refactoring, coding agent workflow
+- Related: [The docs sweep](https://signals.forwardfuture.ai/loop-library/loops/overnight-docs-sweep/), [The sub-50 ms page-load loop](https://signals.forwardfuture.ai/loop-library/loops/sub-50ms-page-load-loop/)
+
+## 003 — [The sub-50 ms page-load loop](https://signals.forwardfuture.ai/loop-library/loops/sub-50ms-page-load-loop/)
+
+- Category: Engineering
+- Use when: Use this when a product has a defined set of routes, a stable performance harness, and a 50 ms target that maps to a specific metric and environment.
+- Prompt: Continue optimizing the code for speed. After each significant change, measure page-load performance across every page under the same repeatable test conditions. Continue until every page loads in under 50 ms.
+- Verify: Every page loads in under 50 ms. Use the same benchmark and confirm there are no regressions.
+- Keywords: AI coding agent, page load optimization, performance benchmark, web performance workflow, 50 ms page load
+- Related: [The architecture satisfaction loop](https://signals.forwardfuture.ai/loop-library/loops/architecture-satisfaction-loop/), [The production error sweep](https://signals.forwardfuture.ai/loop-library/loops/production-error-sweep/)
+
+## 004 — [The production error sweep](https://signals.forwardfuture.ai/loop-library/loops/production-error-sweep/)
+
+- Category: Engineering
+- Use when: Use this as a scheduled reliability pass when an agent can read production telemetry, trace failures into the repository, run the relevant tests, and prepare a reviewable fix.
+- Prompt: Review our production logs for errors. If you find an actionable issue, trace it to its root cause, fix it, verify the fix, and open a pull request. If no actionable errors are present, stop without making changes.
+- Verify: Actionable production errors are fixed and verified. Finish with a pull request, or stop when no actionable errors are present.
+- Keywords: AI coding agent, production log review, error triage, root cause analysis, reliability workflow
+- Related: [The docs sweep](https://signals.forwardfuture.ai/loop-library/loops/overnight-docs-sweep/), [The sub-50 ms page-load loop](https://signals.forwardfuture.ai/loop-library/loops/sub-50ms-page-load-loop/)
+
+## 005 — [The 100% test coverage loop](https://signals.forwardfuture.ai/loop-library/loops/100-percent-test-coverage-loop/)
+
+- Category: Engineering
+- Use when: Use this when 100% coverage is an explicit project requirement and the repository has a trustworthy coverage command, clear exclusions, and a test suite that can be run repeatedly.
+- Prompt: Add tests until we have 100% test coverage.
+- Verify: The full test suite passes at 100% coverage. Use the project's coverage report as the source of truth.
+- Keywords: AI coding agent, 100 percent test coverage, test coverage workflow, automated testing, coding agent prompt
+- Related: [The architecture satisfaction loop](https://signals.forwardfuture.ai/loop-library/loops/architecture-satisfaction-loop/), [The production error sweep](https://signals.forwardfuture.ai/loop-library/loops/production-error-sweep/)
+
+## 006 — [The SEO/GEO visibility loop](https://signals.forwardfuture.ai/loop-library/loops/seo-geo-visibility-loop/)
+
+- Category: Content
+- Use when: Use this when a site has a defined set of priority pages and target questions, and you can rerun the same technical crawl and search visibility checks after each change.
+- Prompt: Run an SEO/GEO audit across crawlability, indexation, page intent, titles, internal links, structured data, source citations, and answer-first content. Rank the gaps by expected impact, fix the highest-leverage issue, then rerun the same crawl and target-query benchmark across search engines and AI answer engines. Repeat until no critical technical issues remain, every priority query maps to a clear answer-ready page, and the benchmark shows no high-impact gap left to fix.
+- Verify: Priority pages are indexable, answer-ready, and technically sound. The repeatable crawl and query benchmark finds no remaining high-impact gaps.
+- Keywords: SEO audit, generative engine optimization, GEO workflow, AI search visibility, answer engine optimization
+- Related: [The docs sweep](https://signals.forwardfuture.ai/loop-library/loops/overnight-docs-sweep/), [The production error sweep](https://signals.forwardfuture.ai/loop-library/loops/production-error-sweep/)
+
+## 007 — [The logging coverage loop](https://signals.forwardfuture.ai/loop-library/loops/exhaustive-logging-coverage-loop/)
+
+- Category: Engineering
+- Use when: Use this when important user flows, service boundaries, background jobs, or failure paths are difficult to trace because the system's logging is incomplete or inconsistent.
+- Prompt: Review the system's logging and add missing coverage until every important path produces useful, tested logs.
+- Verify: Every important path emits useful, tested logs. Representative success and failure tests prove coverage without exposing sensitive data.
+- Keywords: AI coding agent, structured logging, observability coverage, logging tests, production diagnostics
+- Related: [The production error sweep](https://signals.forwardfuture.ai/loop-library/loops/production-error-sweep/), [The 100% test coverage loop](https://signals.forwardfuture.ai/loop-library/loops/100-percent-test-coverage-loop/)
+
+## 008 — [The nightly changelog loop](https://signals.forwardfuture.ai/loop-library/loops/nightly-changelog-sweep/)
+
+- Category: Engineering
+- Use when: Use this when a project changes frequently enough that user-facing release notes can drift from merged pull requests, commits, deployments, and product changes.
+- Prompt: Each night, review changes from the previous day and update the changelog with anything users should know.
+- Verify: Every user-relevant change from the previous day is accounted for. The changelog is updated and validated, or the no-change result is recorded.
+- Keywords: AI coding agent, nightly changelog, release notes workflow, changelog automation, daily repository review
+- Related: [The docs sweep](https://signals.forwardfuture.ai/loop-library/loops/overnight-docs-sweep/), [The repository cleanup loop](https://signals.forwardfuture.ai/loop-library/loops/repository-cleanup-loop/)
+
+## 009 — [The quality streak loop](https://signals.forwardfuture.ai/loop-library/loops/quality-streak-loop/)
+
+- Category: Evaluation
+- Use when: Use this when product quality needs a strict consecutive-success bar and failures should permanently improve the test and benchmark suite.
+- Prompt: Test realistic scenarios. When one fails, document it, add regression and benchmark coverage, fix it, and restart the streak. Stop after [N] successful cases in a row.
+- Verify: The latest [N] realistic cases pass in a row. Every earlier failure is documented, fixed, and protected by regression and benchmark coverage.
+- Keywords: AI product evaluation, quality streak, regression testing, benchmark coverage, realistic scenarios
+- Related: [The full product evaluation loop](https://signals.forwardfuture.ai/loop-library/loops/full-product-evaluation-loop/), [The 100% test coverage loop](https://signals.forwardfuture.ai/loop-library/loops/100-percent-test-coverage-loop/)
+
+## 010 — [The full product evaluation loop](https://signals.forwardfuture.ai/loop-library/loops/full-product-evaluation-loop/)
+
+- Category: Evaluation
+- Use when: Use this for an end-to-end product evaluation when quality must be measured across the full feature set rather than a narrow regression or a few hand-picked examples.
+- Prompt: Create [N] realistic scenarios covering every major capability. Before testing, define clear success criteria and choose a consistent evaluation method, such as pass/fail checks or a scoring rubric. Run every scenario under the same conditions and record evidence for each outcome. Fix the underlying cause of anything that does not meet the criteria, rerun the affected scenarios, and then rerun the complete set. Continue until every scenario meets the original quality bar.
+- Verify: Every one of the [N] scenarios meets the defined quality bar. The final evaluated run covers every major capability under the original conditions.
+- Keywords: AI product evaluation, full product testing, response scoring, quality benchmark, feature coverage
+- Related: [The quality streak loop](https://signals.forwardfuture.ai/loop-library/loops/quality-streak-loop/), [The production data cleanup loop](https://signals.forwardfuture.ai/loop-library/loops/production-data-cleanup-loop/)
+
+## 011 — [The test-suite speed loop](https://signals.forwardfuture.ai/loop-library/loops/test-suite-speed-loop/)
+
+- Category: Engineering
+- Use when: Use this when slow tests are delaying local feedback or continuous integration and the project has stable commands for measuring runtime and coverage.
+- Prompt: Optimize the test suite to run as quickly as possible without reducing coverage or changing behavior.
+- Verify: The suite is faster with no coverage or behavior regression. Repeatable timing, the full passing suite, and the original coverage report prove the result.
+- Keywords: AI coding agent, test suite performance, faster CI, test optimization, coverage preservation
+- Related: [The 100% test coverage loop](https://signals.forwardfuture.ai/loop-library/loops/100-percent-test-coverage-loop/), [The sub-50 ms page-load loop](https://signals.forwardfuture.ai/loop-library/loops/sub-50ms-page-load-loop/)
+
+## 012 — [The repository cleanup loop](https://signals.forwardfuture.ai/loop-library/loops/repository-cleanup-loop/)
+
+- Category: Engineering
+- Use when: Use this when abandoned branches, old worktrees, unclear pull requests, or unmerged commits make it difficult to know which repository state still matters.
+- Prompt: Inspect local and remote branches, pull requests, commits, and worktrees. Recover valuable work and clean everything stale until the repository is current and organized.
+- Verify: Valuable work is recovered and remaining repository state is intentional. Branches, pull requests, commits, and worktrees are current, owned, or safely removed with evidence.
+- Keywords: AI coding agent, repository cleanup, git worktree audit, branch hygiene, pull request triage
+- Related: [The stale-safe batch release loop](https://signals.forwardfuture.ai/loop-library/loops/stale-safe-batch-release-loop/), [The nightly changelog loop](https://signals.forwardfuture.ai/loop-library/loops/nightly-changelog-sweep/)
+
+## 013 — [The stale-safe batch release loop](https://signals.forwardfuture.ai/loop-library/loops/stale-safe-batch-release-loop/)
+
+- Category: Operations
+- Use when: Use this when several branches or pull requests may be ready at once and the release must avoid stale worktrees, partial overlays, and incomplete changes.
+- Prompt: Review pending changes and pull requests, exclude stale or unfinished work, combine the valid changes, and release them together.
+- Verify: Only current, complete changes ship in the combined release. The released revision is the latest integrated main that contains every selected change.
+- Keywords: AI release operations, batch release, stale code prevention, pull request coordination, deployment safety
+- Related: [The repository cleanup loop](https://signals.forwardfuture.ai/loop-library/loops/repository-cleanup-loop/), [The post-release baseline loop](https://signals.forwardfuture.ai/loop-library/loops/post-release-baseline-loop/)
+
+## 014 — [The production data cleanup loop](https://signals.forwardfuture.ai/loop-library/loops/production-data-cleanup-loop/)
+
+- Category: Operations
+- Use when: Use this when a production dataset contains records that no longer match a product, policy, taxonomy, or quality definition and the classifier allowed them through.
+- Prompt: Review production records, remove anything that does not meet the allowed definition, improve the classification logic, and verify the remaining data.
+- Verify: Every remaining record meets the allowed definition. Representative classification tests and a post-cleanup audit prove the retained data is valid.
+- Keywords: AI data operations, production data cleanup, classification logic, data quality audit, regression examples
+- Related: [The full product evaluation loop](https://signals.forwardfuture.ai/loop-library/loops/full-product-evaluation-loop/), [The logging coverage loop](https://signals.forwardfuture.ai/loop-library/loops/exhaustive-logging-coverage-loop/)
+
+## 015 — [The post-release baseline loop](https://signals.forwardfuture.ai/loop-library/loops/post-release-baseline-loop/)
+
+- Category: Operations
+- Use when: Use this immediately after a release when future regressions or improvements need to be measured against the exact version now in production.
+- Prompt: After current releases finish, run the standard benchmarks and record the results as the new baseline.
+- Verify: The new baseline belongs to the completed release. Revision, environment, benchmark version, conditions, and results are recorded together.
+- Keywords: AI release operations, post-release benchmark, performance baseline, release verification, benchmark history
+- Related: [The stale-safe batch release loop](https://signals.forwardfuture.ai/loop-library/loops/stale-safe-batch-release-loop/), [The test-suite speed loop](https://signals.forwardfuture.ai/loop-library/loops/test-suite-speed-loop/)
+
+## 016 — [The ticket-to-PR-ready loop](https://signals.forwardfuture.ai/loop-library/loops/ticket-to-pr-ready-loop/)
+
+- Category: Engineering
+- Use when: Use this when a real but loosely written ticket, bug report, or customer complaint needs to become a bounded engineering change with enough proof for a fast review.
+- Prompt: Take this ticket, bug report, failing behavior, or customer complaint and turn it into a review-ready patch. Define the failure clearly and reproduce it in the smallest possible environment. Isolate the root cause and confirm it with evidence, not inference. Implement the smallest credible fix, then verify the before-and-after behavior. If verification fails, return to the root cause and iterate. If the issue cannot be reproduced after two serious attempts, say so clearly. Do not silently expand scope; split broader refactors or separate problems into named follow-ups. Finish with the failure summary, reproduction steps, root cause, fix summary, files changed, verification proof, risks, follow-ups, suggested PR title, and PR description draft.
+- Verify: The failure is fixed, verified, and ready for review. The same behavior reproduces before the fix, no longer reproduces afterward, and the handoff explains the evidence in under two minutes.
+- Keywords: AI coding agent, ticket to pull request, bug reproduction, root cause analysis, review-ready patch
+- Related: [The production error sweep](https://signals.forwardfuture.ai/loop-library/loops/production-error-sweep/), [The quality streak loop](https://signals.forwardfuture.ai/loop-library/loops/quality-streak-loop/)
+
+## 017 — [The customer AI deployment loop](https://signals.forwardfuture.ai/loop-library/loops/customer-ai-deployment-loop/)
+
+- Category: Operations
+- Use when: Use this when an AI workflow must live inside a real customer process and needs validation, approval, gradual rollout, monitoring, and a clear business outcome.
+- Prompt: Manage one customer AI deployment from priority to production outcome. Run this loop when a customer shares a new priority, requests an AI workflow, gives feedback, reports a failure, or reaches a scheduled AI operations review. Start from the customer's current business priority and choose one concrete workflow or improvement to advance. Define the business goal, owner, affected users, systems and APIs, input data, expected output, approval gates, risk level, success criteria, and ROI hypothesis. Build or update the deployment, run a dry run on realistic customer data, record failures and edge cases, fix the smallest underlying issue, and rerun until the dry run passes or a blocker is clear. Release gradually and monitor production. Before stopping, produce a customer-facing update and store the reusable lessons for the next run.
+- Verify: One customer priority reaches a proven terminal state. The workflow reaches its agreed rollout stage, a production issue is fixed, a blocker is escalated with an owner, or a healthy review records the next check.
+- Keywords: customer AI deployment, AI workflow rollout, approval gates, production monitoring, AI ROI
+- Related: [The full product evaluation loop](https://signals.forwardfuture.ai/loop-library/loops/full-product-evaluation-loop/), [The quality streak loop](https://signals.forwardfuture.ai/loop-library/loops/quality-streak-loop/)
+
+## 018 — [The product update podcast loop](https://signals.forwardfuture.ai/loop-library/loops/product-update-podcast-loop/)
+
+- Category: Content
+- Use when: Use this when a product ships frequently enough that users would benefit from a short recurring audio explanation of what changed and how to use it.
+- Prompt: Each night, review any new publicly released features or changes from the repository and identify the ones most meaningful to users. Verify each selected change against the released product, documentation, or release notes. Use the Jellypod MCP to generate a short three-to-five-minute podcast episode explaining how users can take advantage of the new features, why they are important, and how to try them. Review the script and audio for accuracy, clarity, and pronunciation; fix or regenerate anything that does not match the source material. If there were no meaningful public changes, record that result instead of manufacturing an episode.
+- Verify: The episode accurately covers every meaningful public update. Finish with a review-ready three-to-five-minute episode, or a confirmed no-episode result when nothing meaningful shipped.
+- Keywords: AI podcast workflow, product update podcast, Jellypod MCP, release communication, editorial automation
+- Related: [The nightly changelog loop](https://signals.forwardfuture.ai/loop-library/loops/nightly-changelog-sweep/), [The post-release baseline loop](https://signals.forwardfuture.ai/loop-library/loops/post-release-baseline-loop/)
+
+## 019 — [The Clodex adversarial-review loop](https://signals.forwardfuture.ai/loop-library/loops/clodex-adversarial-review-loop/)
+
+- Category: Engineering
+- Use when: Use this for a meaningful code change that benefits from an independent reviewer and may need several structured review-and-fix rounds.
+- Prompt: Run /clodex [task] think hard --max-iter 5 --threshold medium. Plan the task, implement it, ship a pull request, run the Codex adversarial-review code path, fix every finding above the configured threshold, and repeat. Persist the plan, branch, pull request, findings, verdict, and iteration state so the run can resume safely. Remember that threshold names the highest acceptable severity. Stop when Codex approves, only sub-threshold findings remain, or max-iter is reached. Never report a stalled, errored, or exhausted run as approved.
+- Verify: The pull request reaches the configured review bar. Codex approves, only explicitly acceptable findings remain, or the final report truthfully discloses that the iteration cap or an error stopped the loop.
+- Keywords: Clodex, Codex adversarial review, Claude Code plugin, review fix loop, pull request automation
+- Related: [The architecture satisfaction loop](https://signals.forwardfuture.ai/loop-library/loops/architecture-satisfaction-loop/), [The stale-safe batch release loop](https://signals.forwardfuture.ai/loop-library/loops/stale-safe-batch-release-loop/)
+
+## 020 — [The Loop Harness verification loop](https://signals.forwardfuture.ai/loop-library/loops/loop-harness-verification-loop/)
+
+- Category: Engineering
+- Use when: Use this when a recurring repository task should run unattended but one agent must not be allowed to generate and approve the same output.
+- Prompt: On the configured cadence, wake the due loop. Give a Claude session the task-specific skill and let it work in an isolated git worktree. Stage the resulting commits or output files without shipping them. Have a second Claude session verify the staged work against explicit acceptance criteria. If verification fails, ship nothing; preserve the findings and retry on the next cycle. If verification passes, ship the configured output—a pull request, review comments, or Slack message—and update the loop state. Finish with the source revision, staged artifacts, verifier result, delivery status, and next scheduled run.
+- Verify: Only independently verified output ships. A second-agent pass releases the configured output; a failed verification preserves evidence and produces no external change.
+- Keywords: Loop Harness, scheduled coding agent, git worktree isolation, second-agent verification, autonomous agent workflow
+- Related: [The Clodex adversarial-review loop](https://signals.forwardfuture.ai/loop-library/loops/clodex-adversarial-review-loop/), [The docs sweep](https://signals.forwardfuture.ai/loop-library/loops/overnight-docs-sweep/)
+
+## 021 — [The Boeing 747 benchmark](https://signals.forwardfuture.ai/loop-library/loops/boeing-747-benchmark/)
+
+- Category: Design
+- Use when: Use this as a visual benchmark for an agent that can build a complex Three.js scene, inspect its own renders, and improve the result through repeated vision feedback.
+- Prompt: /goal Create the most realistic Boeing 747 you can using Three.js. Use your vision capabilities to create a self-verifiable system, then enter a loop until you are 100% satisfied with the result. Build a repeatable camera system to inspect the aircraft from every required angle. After each significant change, render those same views, identify what looks least realistic, improve it, and inspect again. Preserve the best version as you iterate, and stop only when you are 100% satisfied that no visible issue remains worth fixing.
+- Verify: You are 100% satisfied with the Boeing 747. The camera system shows every required angle, and you cannot identify another visible issue worth improving.
+- Keywords: Boeing 747 benchmark, Three.js agent workflow, vision self-verification, 3D reconstruction loop, camera inspection system
+- Related: [The quality streak loop](https://signals.forwardfuture.ai/loop-library/loops/quality-streak-loop/), [The full product evaluation loop](https://signals.forwardfuture.ai/loop-library/loops/full-product-evaluation-loop/)
+
+## 022 — [War Loops: Autonomous Frontend Designer](https://signals.forwardfuture.ai/loop-library/loops/war-loops-frontend-designer/)
+
+- Category: Design
+- Use when: Use this when a frontend must be reconstructed from a URL or image and fidelity needs to be measured across appearance, motion, and responsive behavior instead of judged from one screenshot.
+- Prompt: Point War Loops at a URL or image. Capture the page with a genuine browser, extract a ground-truth design spec, and produce two self-correcting builds: a polished static mirror in Pencil and a moving code build in Forge. Judge each build against the original across static design, experiential motion, and responsive reflow. After each evaluation, use the surgical critic to target the weakest signals. Repair, do not rebuild: keep what already matches and change only the highest-impact gaps. Repeat until the measures say it matches, fidelity passes, progress stagnates, or the source capture is blocked. Return the best build with its spec, renders, scores, findings, and run metrics.
+- Verify: The build matches the reference across every measured fidelity axis. Static design, experiential motion, and responsive reflow pass their gates, or the best result stops honestly on stagnation or a blocked capture.
+- Keywords: War Loops, autonomous frontend designer, frontend fidelity, visual evaluation loop, responsive motion matching
+- Related: [The full product evaluation loop](https://signals.forwardfuture.ai/loop-library/loops/full-product-evaluation-loop/), [The sub-50 ms page-load loop](https://signals.forwardfuture.ai/loop-library/loops/sub-50ms-page-load-loop/)
+
+## 023 — [The self-improving champion loop](https://signals.forwardfuture.ai/loop-library/loops/self-improving-champion-loop/)
+
+- Category: Evaluation
+- Use when: Use this to improve a prompt, policy, configuration, or other testable artifact when cheap iteration is useful but final acceptance must use fresh evidence.
+- Prompt: Keep three pieces of state in memory: the champion (the best current genome plus its gate score), a budget starting at [N], and a log of every tried genome and score. Each cycle, if the budget is zero, stop and return the champion. Otherwise, reduce the budget by one, read the latest failure in the log, and propose one targeted change to the champion that addresses it. Skip any change already tried. Score the challenger on a working signal: a cheap measure you may tune against. If it is not better than the champion, log it and continue. If it is better, freeze the challenger and run the gate on fresh examples you did not inspect while editing, plus the guard checks in [safety]. Accept the challenger only if its gate score beats the champion by [minimum margin] and no guard regresses; otherwise keep the champion. Log the attempt and repeat. Keep the working signal and gate separate. Treat a suspiciously easy win as Goodhart's law in action and reject it. If you are uncertain, keep the champion.
+- Verify: The budget is exhausted and the best verified champion is returned. Every challenger is logged, the final champion has the strongest accepted gate score, and no accepted change regresses a guard check.
+- Keywords: self-improving loop, champion challenger evaluation, Goodhart prevention, independent evaluation gate, bounded optimization workflow
+- Related: [The full product evaluation loop](https://signals.forwardfuture.ai/loop-library/loops/full-product-evaluation-loop/), [The quality streak loop](https://signals.forwardfuture.ai/loop-library/loops/quality-streak-loop/)
+
+## 024 — [The devil's-advocate loop](https://signals.forwardfuture.ai/loop-library/loops/devils-advocate-design-loop/)
+
+- Category: Evaluation
+- Use when: Use this before committing to an architecture, interface, rollout plan, or other consequential design that benefits from structured adversarial review.
+- Prompt: Argue against your own design until it survives. In each round, a critic sub-agent writes the strongest case that the current approach is wrong and records every objection in /tmp/redteam-{projectname}.md with its evidence, impact, and status. The builder must either fix the weakness and verify the result or record why accepting it is reasonable under the project's stated criteria. The critic then reviews the change or acceptance rationale and may reopen anything that is not supported. Repeat until no new high-impact objection appears and every logged objection is either verified as resolved or explicitly accepted with evidence. Merely answering an objection in the log does not resolve it. If the same unresolved objections repeat for two rounds without new evidence or progress, stop and report the stalemate instead of claiming the design survived.
+- Verify: No high-impact objection remains open. Every logged objection is verified as resolved or explicitly accepted with evidence, or the final report truthfully records a two-round stalemate.
+- Keywords: devil's advocate loop, adversarial design review, critic builder workflow, architecture objection log, red team design process
+- Related: [The architecture satisfaction loop](https://signals.forwardfuture.ai/loop-library/loops/architecture-satisfaction-loop/), [The Clodex adversarial-review loop](https://signals.forwardfuture.ai/loop-library/loops/clodex-adversarial-review-loop/)
+
+## 025 — [The fresh-clone loop](https://signals.forwardfuture.ai/loop-library/loops/fresh-clone-loop/)
+
+- Category: Engineering
+- Use when: Use this to test whether a repository's onboarding instructions really work for a new contributor or a clean CI-style environment.
+- Prompt: Clone the repository into a clean, empty environment with nothing preinstalled, then follow the README exactly as written to get the project running. Every time a step fails, is missing, or quietly assumes something the README never states, record the gap, fix the setup or documentation to remove that assumption, discard the environment, and start again from a fresh clone. Do not carry dependencies, configuration, credentials, or manual fixes from one attempt into the next. Keep a short log of each gap and how you closed it so it does not return. Stop when a brand-new environment goes from clone to running app in one uninterrupted pass using only the documented steps and no outside fix. Finish with the gaps closed and the exact commands a new contributor now runs from scratch.
+- Verify: A clean environment reaches a running app using only the README. The final from-scratch run is uninterrupted and needs no unstated step, preinstalled tool, configuration, or manual repair.
+- Keywords: fresh clone loop, README verification, developer onboarding test, clean environment setup, repository documentation workflow
+- Related: [The docs sweep](https://signals.forwardfuture.ai/loop-library/loops/overnight-docs-sweep/), [The repository cleanup loop](https://signals.forwardfuture.ai/loop-library/loops/repository-cleanup-loop/)
+
+## 026 — [The Infinite Clickbait loop](https://signals.forwardfuture.ai/loop-library/loops/infinite-clickbait-loop/)
+
+- Category: Design
+- Use when: Use this when a video topic and asset set are ready but the thumbnail needs several structured ideation and critique rounds before production.
+- Prompt: The video is about [video subject]. Using [assets], make ten thumbnail concepts and score each one against [inspiration channel]'s YouTube thumbnails using a consistent rubric: clarity at small size, curiosity, emotional pull, visual contrast, and accuracy to the video. Select the top three, identify the weakest part of each concept, improve them, and rescore them with the same rubric. Continue iterating the strongest concept until you're satisfied it's click-baity enough without promising something the video does not deliver. Return the winning concept, two runners-up, their final scores, and the reasoning behind the choice.
+- Verify: You are satisfied the winning thumbnail is click-baity enough. The winner outperforms the alternatives on the fixed rubric, remains legible at thumbnail size, and accurately represents the video.
+- Keywords: Infinite Clickbait, YouTube thumbnail loop, thumbnail iteration workflow, clickbait scoring rubric, AI visual design
+- Related: [The Boeing 747 benchmark](https://signals.forwardfuture.ai/loop-library/loops/boeing-747-benchmark/), [The full product evaluation loop](https://signals.forwardfuture.ai/loop-library/loops/full-product-evaluation-loop/)


### PR DESCRIPTION
## What changed

- Add an installable `loop-library` agent skill with a question-led workflow for finding, adapting, and designing bounded loops.
- Bundle a generated offline snapshot of all 26 published loops and link recommendations back to the canonical Loop Library.
- Keep the skill catalog synchronized with `scripts/loop-data.mjs` through a generator and repository drift checks.
- Document the global `npx skills` install command.

## Why

People should be able to bring the Loop Library directly into Codex, Claude Code, Cursor, and other compatible coding agents. The skill helps them select an existing loop when one fits and design a new loop with explicit feedback, verification, stopping conditions, budgets, approvals, and handoffs when one does not.

## Validation

- Skill Creator `quick_validate.py`
- `npx skills add . --list` discovery smoke test
- clean copy install into a temporary Codex project, including bundled references
- `node scripts/check.mjs`
- full Loop Library page/social generation checks
- Worker test suite: 12 passed
- `git diff --check`