### PR TITLE
[codex] Promote Loop Library skill on homepage

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -361,8 +361,20 @@ assert(!html.includes('data-type='));
 assert(!html.includes('class="cell-type"'));
 assert(!html.includes("type-badge"));
 assert(!html.includes('<th scope="col">Type</th>'));
-assert(html.includes("./styles.css?v=20260618-categories"));
-assert(html.includes("./script.js?v=20260618-categories"));
+assert(html.includes("./styles.css?v=20260619-skill-promo"));
+assert(html.includes("./script.js?v=20260619-skill-promo"));
+assert(html.includes('id="agent-skill"'));
+assert(html.includes("Bring the Loop Library into your coding agent."));
+assert(
+  html.includes(
+    "npx skills add mberman84/loop-library --skill loop-library",
+  ),
+);
+assert(
+  html.includes(
+    "https://github.com/mberman84/loop-library/tree/main/skills/loop-library",
+  ),
+);
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
 assert.equal((html.match(/https:\/\/here\.now\/r\/signals/g) || []).length, 2);
 assert.equal((html.match(/aria-label="Hosted by here\.now"/g) || []).length, 2);
@@ -408,6 +420,8 @@ assert(css.includes(".related-loop-link"));
 assert(css.includes(".category-filters"));
 assert(css.includes(".category-filter.is-active"));
 assert(css.includes(".loop-category"));
+assert(css.includes(".skill-promo"));
+assert(css.includes(".skill-copy-button"));
 assert(!css.includes(".type-badge"));
 assert(!css.includes(".type-goal"));
 assert(!css.includes(".type-triggered"));
@@ -448,6 +462,8 @@ assert(script.includes('candidate.setAttribute("aria-pressed", String(isActive))
 assert(script.includes('themeToggle.addEventListener("click"'));
 assert(script.includes("window.localStorage.setItem(THEME_STORAGE_KEY, theme)"));
 assert(script.includes('button.closest("[data-copy-root]")'));
+assert(script.includes('document.querySelector("[data-copy-skill-command]")'));
+assert(script.includes("Install command copied to clipboard."));
 assert(!script.includes("innerHTML"));
 assert(
   workerSource.includes(

--- a/site/index.html
+++ b/site/index.html
@@ -104,7 +104,7 @@
       href="https://signals.forwardfuture.ai/loop-library/feed.xml"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260618-categories" />
+    <link rel="stylesheet" href="./styles.css?v=20260619-skill-promo" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -313,7 +313,7 @@
         ]
       }
     </script>
-    <script src="./script.js?v=20260618-categories" defer></script>
+    <script src="./script.js?v=20260619-skill-promo" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>
@@ -334,6 +334,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="#library">Loops</a>
+        <a href="#agent-skill">Install skill</a>
         <a href="#weekly">Weekly picks</a>
         <button
           class="theme-toggle"
@@ -385,6 +386,48 @@
             Each one includes clear checks and tells the agent when to stop.
           </p>
         </div>
+
+        <section
+          class="skill-promo"
+          id="agent-skill"
+          aria-labelledby="agent-skill-title"
+        >
+          <div class="skill-promo-copy">
+            <p class="skill-promo-kicker">Installable agent skill</p>
+            <h2 id="agent-skill-title">
+              Bring the Loop Library into your coding agent.
+            </h2>
+            <p>
+              Find the right published loop, or answer a few focused questions
+              to design one with clear checks and stopping conditions.
+            </p>
+          </div>
+
+          <div class="skill-promo-actions">
+            <p class="skill-install-label">Install globally</p>
+            <code class="skill-install-command" data-skill-install-command
+              >npx skills add mberman84/loop-library --skill loop-library
+              -g</code
+            >
+            <div class="skill-action-row">
+              <button
+                class="skill-copy-button"
+                type="button"
+                data-copy-skill-command
+              >
+                <span>Copy install command</span>
+              </button>
+              <a
+                class="skill-github-link"
+                href="https://github.com/mberman84/loop-library/tree/main/skills/loop-library"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View on GitHub
+              </a>
+            </div>
+          </div>
+        </section>
 
         <div class="library-controls">
           <label class="search-control">

--- a/site/script.js
+++ b/site/script.js
@@ -180,6 +180,33 @@ document.querySelectorAll(".copy-button").forEach((button) => {
   });
 });
 
+const skillCopyButton = document.querySelector("[data-copy-skill-command]");
+const skillInstallCommand = document.querySelector(
+  "[data-skill-install-command]",
+);
+
+if (skillCopyButton && skillInstallCommand) {
+  skillCopyButton.addEventListener("click", async () => {
+    const label = skillCopyButton.querySelector("span");
+    const command = skillInstallCommand.textContent.replace(/\s+/g, " ").trim();
+
+    if (!label || !command) {
+      return;
+    }
+
+    try {
+      await copyText(command);
+      label.textContent = "Copied";
+      showToast("Install command copied to clipboard.");
+      window.setTimeout(() => {
+        label.textContent = "Copy install command";
+      }, 1800);
+    } catch {
+      showToast("Copy failed. Select the install command instead.");
+    }
+  });
+}
+
 const form = document.querySelector("#loop-form");
 const formStatus = document.querySelector("#form-status");
 const submitButton = form?.querySelector(".submit-button");

--- a/site/styles.css
+++ b/site/styles.css
@@ -380,6 +380,112 @@ code {
   max-width: 920px;
 }
 
+.skill-promo {
+  display: grid;
+  align-items: end;
+  gap: clamp(28px, 5vw, 72px);
+  margin-top: 32px;
+  padding: clamp(24px, 4vw, 44px);
+  border: 1px solid var(--charcoal);
+  color: var(--charcoal);
+  background: var(--orange);
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+}
+
+.skill-promo-copy h2 {
+  max-width: 760px;
+  margin-bottom: 14px;
+  font-size: clamp(2rem, 4vw, 3.65rem);
+  font-weight: 800;
+  letter-spacing: -0.06em;
+  line-height: 0.98;
+}
+
+.skill-promo-copy > p:last-child {
+  max-width: 660px;
+  margin-bottom: 0;
+  font-size: clamp(1rem, 1.4vw, 1.15rem);
+}
+
+.skill-promo-kicker,
+.skill-install-label {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.skill-promo-kicker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.skill-promo-kicker::before {
+  width: 24px;
+  height: 7px;
+  background: var(--charcoal);
+  content: "";
+}
+
+.skill-install-label {
+  margin-bottom: 8px;
+}
+
+.skill-install-command {
+  display: block;
+  padding: 14px 16px;
+  border: 1px solid var(--charcoal);
+  color: var(--charcoal);
+  background: var(--light);
+  font-size: 0.76rem;
+  overflow-wrap: anywhere;
+}
+
+.skill-action-row {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin-top: 12px;
+}
+
+.skill-copy-button,
+.skill-github-link {
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.skill-copy-button {
+  min-height: 40px;
+  padding: 9px 13px;
+  border: 1px solid var(--charcoal);
+  color: var(--light);
+  background: var(--charcoal);
+  cursor: pointer;
+}
+
+.skill-copy-button:hover,
+.skill-copy-button:focus-visible {
+  color: var(--charcoal);
+  background: var(--light);
+}
+
+.skill-github-link {
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+}
+
+.skill-github-link:hover,
+.skill-github-link:focus-visible {
+  text-decoration-thickness: 4px;
+}
+
+.skill-promo + .library-controls {
+  margin-top: 24px;
+}
+
 .section-heading {
   display: grid;
   align-items: end;
@@ -1314,6 +1420,15 @@ code {
     max-width: 620px;
   }
 
+  .skill-promo {
+    align-items: start;
+    grid-template-columns: 1fr;
+  }
+
+  .skill-promo-actions {
+    max-width: 720px;
+  }
+
   .newsletter-layout {
     align-items: start;
     grid-template-columns: 1fr;
@@ -1515,6 +1630,24 @@ code {
 
   .section-heading h2 {
     font-size: 2.4rem;
+  }
+
+  .skill-promo {
+    padding: 22px 18px;
+  }
+
+  .skill-action-row {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .skill-copy-button {
+    width: 100%;
+  }
+
+  .skill-github-link {
+    align-self: flex-start;
   }
 
   .newsletter-form-row {


### PR DESCRIPTION
## What changed

- Add a prominent FF Orange skill panel directly beneath the Loop Library hero.
- Include the global `npx skills` install command, one-click copy behavior, and a direct link to the skill on GitHub.
- Add an `Install skill` navigation link and responsive layouts for desktop, tablet, and mobile.
- Add repository checks covering the promotion markup, styling, command, link, and interaction hook.

## Why

The installable skill should be discoverable from the Loop Library itself, not only from the repository README. The new panel makes the practical payoff and install path visible before the catalog.

## Validation

- full Loop Library page and social generation checks
- `node scripts/check.mjs`
- Worker test suite: 12 passed
- desktop and mobile visual review in light and dark themes
- responsive overflow sweep at 320, 390, 760, 900, 1024, and 1440 px
- clipboard smoke test verified the exact install command
- `git diff --check`