### PR TITLE
[codex] Name published loops as Loop Library loops

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -159,6 +159,8 @@ assert(requestedConceptSlugs.every((slug) => slugs.has(slug)));
 assert.deepEqual(loopDirectories.sort(), [...slugs].sort());
 assert.equal(skillCatalog, renderSkillCatalog());
 assert(skillSource.startsWith("---\nname: loop-library\ndescription:"));
+assert(skillSource.includes("reuse a published Loop Library loop"));
+assert(!skillSource.includes("published Forward Future loop"));
 assert(skillSource.includes("## Run the design interview"));
 assert(skillSource.includes("## Deliver the loop"));
 assert(skillInterface.includes('display_name: "Loop Library"'));

--- a/skills/loop-library/SKILL.md
+++ b/skills/loop-library/SKILL.md
@@ -5,7 +5,7 @@ description: Find, compare, adapt, and design repeatable AI-agent loops with exp
 
 # Loop Library
 
-Help the user reuse a published Forward Future loop when one fits. Otherwise,
+Help the user reuse a published Loop Library loop when one fits. Otherwise,
 adapt the closest loop or design a new one through a focused interview. Treat a
 loop as a feedback system with terminal states, not as permission for endless
 autonomy.


### PR DESCRIPTION
## What changed

- Replace “published Forward Future loop” with “published Loop Library loop” in the installable skill.
- Add a repository assertion that preserves the corrected product ownership language.

## Why

Published loops belong to the Loop Library. Forward Future may host or present the site, but it is not the loop’s product name.

## Validation

- Skill Creator `quick_validate.py`
- `node scripts/build-skill-catalog.mjs`
- `node scripts/check.mjs`
- `npx skills add . --list`
- `git diff --check`