### PR TITLE
[codex] Add 25-item catalog pagination

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -446,8 +446,13 @@ assert(!html.includes('data-type='));
 assert(!html.includes('class="cell-type"'));
 assert(!html.includes("type-badge"));
 assert(!html.includes('<th scope="col">Type</th>'));
-assert(html.includes("./styles.css?v=20260619-skill-promo-compact"));
-assert(html.includes("./script.js?v=20260619-skill-promo-compact"));
+assert(html.includes("./styles.css?v=20260619-pagination"));
+assert(html.includes("./script.js?v=20260619-pagination"));
+assert(html.includes('id="library-pagination"'));
+assert(html.includes('aria-label="Loop pages"'));
+assert(html.includes('id="pagination-previous"'));
+assert(html.includes('id="pagination-status"'));
+assert(html.includes('id="pagination-next"'));
 assert(html.includes('id="agent-skill"'));
 assert(html.includes("Use Loop Library in your coding agent."));
 assert(
@@ -513,6 +518,10 @@ assert(css.includes(".related-loop-link"));
 assert(css.includes(".category-filters"));
 assert(css.includes(".category-filter.is-active"));
 assert(css.includes(".loop-category"));
+assert(css.includes(".pagination"));
+assert(css.includes(".pagination-button:disabled"));
+assert(css.includes("scroll-margin-top: 80px"));
+assert(css.includes(".pagination-button,\n  .pagination-status"));
 assert(css.includes(".skill-promo"));
 assert(css.includes(".skill-copy-button"));
 assert(css.includes("border-left: 5px solid var(--orange)"));
@@ -549,11 +558,25 @@ assert(script.includes("bytes[6] = (bytes[6] & 0x0f) | 0x40"));
 assert(script.includes("bytes[8] = (bytes[8] & 0x3f) | 0x80"));
 assert(!script.includes("./.herenow/data/"));
 assert(script.includes('document.querySelectorAll(".loop-row")'));
-assert(script.includes('searchInput.addEventListener("input", updateLibrary)'));
-assert(script.includes('searchInput.addEventListener("search", updateLibrary)'));
+assert(script.includes("const PAGE_SIZE = 25"));
+assert(script.includes("Math.ceil(totalMatches / PAGE_SIZE)"));
+assert(script.includes("matchingRows.slice(pageStart, pageEnd)"));
+assert(script.includes('searchInput.addEventListener("input", resetSearchPage)'));
+assert(script.includes('searchInput.addEventListener("search", resetSearchPage)'));
 assert(script.includes('document.querySelectorAll("[data-category-filter]")'));
 assert(script.includes('let activeCategory = "all"'));
+assert(script.includes("let currentPage = 1"));
 assert(script.includes('row.dataset.category === activeCategory'));
+assert(script.includes('paginationPrevious.addEventListener("click"'));
+assert(script.includes('paginationNext.addEventListener("click"'));
+assert(script.includes("pagination.hidden = totalPages <= 1"));
+assert(script.includes("function focusFirstVisibleLoop()"));
+assert(script.includes("firstVisibleTitle.focus({ preventScroll: true })"));
+assert(
+  script.includes(
+    'firstVisibleTitle.scrollIntoView({ behavior: "instant", block: "start" })',
+  ),
+);
 assert(script.includes('candidate.setAttribute("aria-pressed", String(isActive))'));
 assert(script.includes('themeToggle.addEventListener("click"'));
 assert(script.includes("window.localStorage.setItem(THEME_STORAGE_KEY, theme)"));

--- a/site/index.html
+++ b/site/index.html
@@ -116,7 +116,7 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.md"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260619-skill-promo-compact" />
+    <link rel="stylesheet" href="./styles.css?v=20260619-pagination" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -343,7 +343,7 @@
         ]
       }
     </script>
-    <script src="./script.js?v=20260619-skill-promo-compact" defer></script>
+    <script src="./script.js?v=20260619-pagination" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>
@@ -1704,6 +1704,35 @@
           <p>Try another category, broaden your search, or submit the workflow.</p>
           <a href="#submit">Submit a loop</a>
         </div>
+
+        <nav
+          class="pagination"
+          id="library-pagination"
+          aria-label="Loop pages"
+          hidden
+        >
+          <button
+            class="pagination-button"
+            id="pagination-previous"
+            type="button"
+          >
+            Previous
+          </button>
+          <p
+            class="pagination-status"
+            id="pagination-status"
+            aria-live="polite"
+          >
+            Page 1 of 2
+          </p>
+          <button
+            class="pagination-button"
+            id="pagination-next"
+            type="button"
+          >
+            Next
+          </button>
+        </nav>
 
         <p class="loop-guide">
           <strong>A useful loop specifies:</strong>

--- a/site/script.js
+++ b/site/script.js
@@ -61,9 +61,15 @@ const categoryFilters = [
 ];
 const resultsCount = document.querySelector("#results-count");
 const emptyState = document.querySelector("#empty-state");
+const pagination = document.querySelector("#library-pagination");
+const paginationPrevious = document.querySelector("#pagination-previous");
+const paginationNext = document.querySelector("#pagination-next");
+const paginationStatus = document.querySelector("#pagination-status");
 const toast = document.querySelector("#toast");
+const PAGE_SIZE = 25;
 
 let activeCategory = "all";
+let currentPage = 1;
 let toastTimer;
 
 function normalize(value) {
@@ -76,36 +82,81 @@ function updateLibrary() {
   }
 
   const query = normalize(searchInput.value);
-  let visibleCount = 0;
-
-  loopRows.forEach((row) => {
+  const matchingRows = loopRows.filter((row) => {
     const searchableText = `${row.dataset.search} ${row.textContent}`;
     const matchesSearch =
       query.length === 0 || normalize(searchableText).includes(query);
     const matchesCategory =
       activeCategory === "all" || row.dataset.category === activeCategory;
-    const isVisible = matchesSearch && matchesCategory;
-
-    row.hidden = !isVisible;
-    if (isVisible) {
-      visibleCount += 1;
-    }
+    return matchesSearch && matchesCategory;
   });
 
-  resultsCount.textContent = `Showing ${visibleCount} ${
-    visibleCount === 1 ? "loop" : "loops"
-  }`;
-  emptyState.hidden = visibleCount !== 0;
+  const totalMatches = matchingRows.length;
+  const totalPages = Math.max(1, Math.ceil(totalMatches / PAGE_SIZE));
+  currentPage = Math.min(currentPage, totalPages);
+
+  const pageStart = (currentPage - 1) * PAGE_SIZE;
+  const pageEnd = Math.min(pageStart + PAGE_SIZE, totalMatches);
+  const pageRows = new Set(matchingRows.slice(pageStart, pageEnd));
+
+  loopRows.forEach((row) => {
+    row.hidden = !pageRows.has(row);
+  });
+
+  if (totalMatches === 0) {
+    resultsCount.textContent = "Showing 0 loops";
+  } else if (totalMatches === 1) {
+    resultsCount.textContent = "Showing 1 loop";
+  } else {
+    resultsCount.textContent = `Showing ${pageStart + 1}–${pageEnd} of ${totalMatches} loops`;
+  }
+
+  emptyState.hidden = totalMatches !== 0;
+
+  if (
+    pagination &&
+    paginationPrevious &&
+    paginationNext &&
+    paginationStatus
+  ) {
+    pagination.hidden = totalPages <= 1;
+    paginationPrevious.disabled = currentPage === 1;
+    paginationNext.disabled = currentPage === totalPages;
+    paginationStatus.textContent = `Page ${currentPage} of ${totalPages}`;
+  }
+}
+
+function focusFirstVisibleLoop() {
+  const firstVisibleTitle = loopRows
+    .find((row) => !row.hidden)
+    ?.querySelector(".loop-title-link");
+
+  if (!firstVisibleTitle) {
+    return;
+  }
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      firstVisibleTitle.focus({ preventScroll: true });
+      firstVisibleTitle.scrollIntoView({ behavior: "instant", block: "start" });
+    });
+  });
 }
 
 if (searchInput) {
-  searchInput.addEventListener("input", updateLibrary);
-  searchInput.addEventListener("search", updateLibrary);
+  const resetSearchPage = () => {
+    currentPage = 1;
+    updateLibrary();
+  };
+
+  searchInput.addEventListener("input", resetSearchPage);
+  searchInput.addEventListener("search", resetSearchPage);
 }
 
 categoryFilters.forEach((filter) => {
   filter.addEventListener("click", () => {
     activeCategory = filter.dataset.categoryFilter;
+    currentPage = 1;
 
     categoryFilters.forEach((candidate) => {
       const isActive = candidate === filter;
@@ -116,6 +167,24 @@ categoryFilters.forEach((filter) => {
     updateLibrary();
   });
 });
+
+if (paginationPrevious) {
+  paginationPrevious.addEventListener("click", () => {
+    if (currentPage > 1) {
+      currentPage -= 1;
+      updateLibrary();
+      focusFirstVisibleLoop();
+    }
+  });
+}
+
+if (paginationNext) {
+  paginationNext.addEventListener("click", () => {
+    currentPage += 1;
+    updateLibrary();
+    focusFirstVisibleLoop();
+  });
+}
 
 updateLibrary();
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -684,6 +684,7 @@ code {
 }
 
 .loop-title-link {
+  scroll-margin-top: 80px;
   text-decoration-color: var(--orange);
   text-decoration-thickness: 2px;
   text-underline-offset: 4px;
@@ -753,6 +754,63 @@ code {
 
 .empty-state a {
   font-weight: 700;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 20px 0 0;
+}
+
+.pagination[hidden] {
+  display: none;
+}
+
+.pagination-button {
+  min-width: 92px;
+  padding: 8px 12px;
+  border: 1px solid var(--ink);
+  color: var(--ink);
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.pagination-button:hover,
+.pagination-button:focus-visible {
+  color: var(--solid-foreground);
+  background: var(--solid-background);
+}
+
+.pagination-button:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.pagination-button:disabled {
+  border-color: var(--line);
+  color: var(--muted);
+  background: transparent;
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.pagination-status {
+  min-width: 92px;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 .loop-guide {
@@ -1615,6 +1673,23 @@ code {
 
   .here-now-credit strong {
     font-size: 0.72rem;
+  }
+
+  .pagination {
+    gap: 8px;
+  }
+
+  .pagination-button,
+  .pagination-status {
+    min-width: 0;
+  }
+
+  .pagination-button {
+    padding-inline: 10px;
+  }
+
+  .pagination-status {
+    flex: 1;
   }
 
   .section-heading h2 {


### PR DESCRIPTION
## What changed

- paginate the Loop Library catalog at 25 loops per page
- reset pagination when search or category filters change
- report the visible result range and hide pagination for one-page result sets
- move keyboard focus to the first loop after page changes
- keep controls accessible and responsive down to 320 px

## Why

The catalog has grown beyond a comfortable single page. Pagination keeps the initial list bounded while preserving the existing client-side search and category filters.

## Validation

- full catalog generation and repository checks
- 12 Worker tests
- here.now branding validator across 30 HTML pages
- browser verification for page 1/page 2, search and category resets, focus behavior, and 320/390 px layouts
- structured autoreview clean with no actionable findings