### PR TITLE
[codex] Explain Loop Library skill up front

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Loop Library
 
+The Loop Library skill is an installable guide for your AI agent. Tell it what
+you want to get done and it can find a published loop, adapt one to your
+situation, or help you design a new one through a short conversation.
+
 Loop Library is a collection of reusable ways to get better work from AI
 agents. Each loop tells an agent what to do, how to check its work, what to try
 next, and when to stop.


### PR DESCRIPTION
## What changed

Added a short paragraph at the top of the README explaining that the Loop Library skill is installable and can find, adapt, or help design a loop.

## Why

The README explained loops well, but readers still had to scroll before learning what the skill itself was. The new lead answers that immediately without changing the existing explanation.

## Validation

- full repository build and validation suite
- Worker test suite: 12 passing
- `git diff --check`
- structured Codex autoreview: clean, no accepted or actionable findings