### PR TITLE
[codex] Improve SEO and answer-ready pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,14 @@ jobs:
           node --check scripts/build-skill-catalog.mjs
           node --check scripts/build-loop-pages.mjs
           node --check scripts/build-social-images.mjs
+          node --check scripts/audit-seo-geo.mjs
           node --check scripts/loop-data.mjs
           node --check site/script.js
+          node scripts/audit-seo-geo.mjs
           node scripts/check.mjs
           python3 -m json.tool site/.herenow/data.json >/dev/null
           python3 -m json.tool site/catalog.json >/dev/null
+          python3 -m json.tool scripts/seo-geo-query-benchmark.json >/dev/null
           git diff --check
 
       - name: Test form Worker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,16 @@
   node scripts/build-skill-catalog.mjs
   node scripts/build-loop-pages.mjs
   node scripts/build-social-images.mjs
+  node --check scripts/audit-seo-geo.mjs
   node --check scripts/build-social-images.mjs
   node --check site/script.js
   node --check scripts/build-loop-pages.mjs
   node --check scripts/loop-data.mjs
+  node scripts/audit-seo-geo.mjs
   node scripts/check.mjs
   npm --prefix worker run check
   python3 -m json.tool site/.herenow/data.json >/dev/null
+  python3 -m json.tool scripts/seo-geo-query-benchmark.json >/dev/null
   git diff --check
   ```
 

--- a/README.md
+++ b/README.md
@@ -117,13 +117,16 @@ npm ci --prefix worker
 node scripts/build-skill-catalog.mjs
 node scripts/build-loop-pages.mjs
 node scripts/build-social-images.mjs
+node --check scripts/audit-seo-geo.mjs
 node --check scripts/build-social-images.mjs
 node --check site/script.js
 node --check scripts/build-loop-pages.mjs
 node --check scripts/loop-data.mjs
+node scripts/audit-seo-geo.mjs
 node scripts/check.mjs
 npm --prefix worker run check
 python3 -m json.tool site/.herenow/data.json >/dev/null
+python3 -m json.tool scripts/seo-geo-query-benchmark.json >/dev/null
 git diff --check
 ```
 

--- a/audits/seo-geo-2026-06-19.md
+++ b/audits/seo-geo-2026-06-19.md
@@ -1,0 +1,84 @@
+# SEO/GEO audit — 2026-06-19
+
+Captured at 2026-06-19 10:57 PDT. The external benchmark is a pre-publish
+baseline against the current production site. The fixed crawl is local until a
+production deployment is explicitly approved.
+
+## Scope and frozen query set
+
+The crawl covers crawlability, indexation, page intent, titles, internal links,
+structured data, source citations, answer-first content, and one mapped page for
+every priority query. The same four queries were used without rewriting them:
+
+| ID | Query | Expected answer page |
+| --- | --- | --- |
+| Generic discovery | `AI agent loop library reusable prompts` | Homepage |
+| Generic definition | `what is an AI agent loop` | Homepage |
+| Detail intent | `repository cleanup loop for coding agents` | Repository cleanup detail page |
+| Brand entity | `Forward Future Loop Library` | Homepage |
+
+## Crawl results
+
+| Run | Pages | Query mappings | Critical | High | Medium | Low |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Integrated `origin/main` baseline | 30 | 33 | 0 | 3 | 0 | 8 |
+| Local rerun after fixes | 30 | 33 | 0 | 0 | 0 | 8 |
+
+The three baseline high findings were:
+
+- The homepage did not clearly answer the generic definition query or state a
+  stop condition.
+- Every one of the 29 detail pages linked to the missing homepage fragment
+  `#tips`.
+
+The local rerun verifies that all internal link targets and fragments resolve.
+The eight remaining low findings are titles of 61–62 characters or descriptions
+of 163–165 characters. None blocks crawling, indexing, or query-to-page mapping.
+
+A separate HTTP crawl of production returned `200` for the sitemap and all 30
+canonical pages. All 30 pages had the expected self-canonical and explicit
+`index, follow` directive. The custom domain's root `robots.txt` returned `200`
+and `User-agent: * / Allow: /`; it does not currently advertise the sitemap.
+
+## Search and answer-engine baseline
+
+Conditions: en-US, United States; Google used `pws=0`; ChatGPT Search used its
+explicit Web search mode. A blocked engine was recorded rather than changing a
+query.
+
+| Query | Google Search | DuckDuckGo | Bing | Google AI Overview | ChatGPT Search | Duck.ai |
+| --- | --- | --- | --- | --- | --- | --- |
+| Generic discovery | Canonical homepage #1 | Canonical absent; EveryDev's Loop Library listing #1 | CAPTCHA | Cites canonical homepage | Canonical absent | Terms gate |
+| Generic definition | Canonical absent from first page | Canonical absent | CAPTCHA | Does not cite canonical site | Answers the query but omits canonical site | Terms gate |
+| Detail intent | Canonical detail page #1 | Canonical absent | CAPTCHA | Does not cite canonical detail page | Produces a cleanup loop but omits canonical site | Terms gate |
+| Brand entity | Canonical homepage #1 | Canonical absent; GitHub repository #1 | CAPTCHA | No overview observed | Does not resolve the Loop Library entity | Terms gate |
+
+## Ranked gaps and actions
+
+1. **High — missing answer-ready definition:** fixed with a concise homepage
+   answer, explicit stop condition, visible citations to the
+   [Claude Agent SDK loop documentation](https://code.claude.com/docs/en/agent-sdk/agent-loop)
+   and [ReAct paper](https://arxiv.org/abs/2210.03629), plus `DefinedTerm`
+   structured data.
+2. **High — broken sitewide internal link:** fixed in the page generator. Each
+   detail page now links to the definition with the descriptive anchor “What is
+   a loop?”.
+3. **Medium — ChatGPT Search does not retrieve the canonical site:** no further
+   high-confidence content fix remains. Google already ranks the same canonical
+   pages #1, so the next valid step is publish, submit the sitemap, and allow the
+   secondary index to recrawl.
+4. **Medium — DuckDuckGo does not return the canonical site directly:** the
+   entity is visible through the #1 GitHub or third-party result. Treat as
+   index-discovery lag and submit the sitemap after publish.
+5. **Low — eight slightly long snippets:** monitor real result truncation before
+   shortening useful copy.
+6. **Low — root `robots.txt` omits a sitemap directive:** it allows all relevant
+   crawlers and the sitemap is live and linked from every page. Add the sitemap
+   at the root-domain owner when that configuration is next changed.
+
+## Current stop state
+
+The local crawl has no critical, high, or medium technical/content findings,
+and all 33 priority intents map to an answer-ready page. The external benchmark
+must be rerun after the fixed artifact is deployed and recrawled; this report
+does not claim that local changes have already altered live search results.

--- a/scripts/audit-seo-geo.mjs
+++ b/scripts/audit-seo-geo.mjs
@@ -1,0 +1,395 @@
+import { access, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { loops, site } from "./loop-data.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const siteRoot = path.join(root, "site");
+const benchmark = JSON.parse(
+  await readFile(
+    path.join(root, "scripts", "seo-geo-query-benchmark.json"),
+    "utf8",
+  ),
+);
+
+const findings = [];
+
+function addFinding(severity, area, message, page = null) {
+  findings.push({ severity, area, message, ...(page ? { page } : {}) });
+}
+
+function escapePattern(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function textContent(html) {
+  return html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replaceAll("&amp;", "&")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function elementText(html, tag, attributes = "") {
+  const attributePattern = attributes
+    ? `(?=[^>]*${escapePattern(attributes)})`
+    : "";
+  const match = html.match(
+    new RegExp(`<${tag}\\b${attributePattern}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i"),
+  );
+  return match ? textContent(match[1]) : "";
+}
+
+function attributeValue(html, tag, attribute, selectorAttribute, selectorValue) {
+  const tagMatches = html.match(new RegExp(`<${tag}\\b[^>]*>`, "gi")) || [];
+  const selectorPattern = new RegExp(
+    `${selectorAttribute}=["']${escapePattern(selectorValue)}["']`,
+    "i",
+  );
+  const selected = tagMatches.find((candidate) => selectorPattern.test(candidate));
+  return selected?.match(
+    new RegExp(`${attribute}=["']([^"']+)["']`, "i"),
+  )?.[1] || "";
+}
+
+function jsonLd(html) {
+  return (html.match(/<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/gi) || [])
+    .map((block) => block.replace(/^.*?<script type="application\/ld\+json">\s*/i, "").replace(/\s*<\/script>\s*$/i, ""))
+    .map((source) => JSON.parse(source));
+}
+
+function normalize(value) {
+  return value.toLowerCase().replace(/[’']/g, "'").replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+const homepage = await readFile(path.join(siteRoot, "index.html"), "utf8");
+const sitemap = await readFile(path.join(siteRoot, "sitemap.xml"), "utf8");
+const pages = new Map([["index.html", homepage]]);
+
+await Promise.all(
+  loops.map(async (loop) => {
+    const relativePath = `loops/${loop.slug}/index.html`;
+    pages.set(
+      relativePath,
+      await readFile(path.join(siteRoot, relativePath), "utf8"),
+    );
+  }),
+);
+
+const expectedUrls = [
+  site.baseUrl,
+  ...loops.map((loop) => `${site.baseUrl}loops/${loop.slug}/`),
+];
+const siteUrl = new URL(site.baseUrl);
+const internalTargets = new Map();
+
+for (const url of expectedUrls) {
+  if (!sitemap.includes(`<loc>${url}</loc>`)) {
+    addFinding("critical", "crawlability", `Sitemap is missing ${url}.`);
+  }
+}
+
+if ((sitemap.match(/<loc>/g) || []).length !== expectedUrls.length) {
+  addFinding(
+    "high",
+    "crawlability",
+    `Sitemap URL count does not match the ${expectedUrls.length} canonical HTML pages.`,
+  );
+}
+
+const titles = new Map();
+const descriptions = new Map();
+const incomingLinks = new Map(expectedUrls.map((url) => [url, 0]));
+
+for (const [relativePath, html] of pages) {
+  const isHome = relativePath === "index.html";
+  const expectedUrl = isHome
+    ? site.baseUrl
+    : `${site.baseUrl}${relativePath.replace(/index\.html$/, "")}`;
+  const title = elementText(html, "title");
+  const description = attributeValue(html, "meta", "content", "name", "description");
+  const robots = attributeValue(html, "meta", "content", "name", "robots");
+  const robotsDirectives = new Set(
+    robots
+      .toLowerCase()
+      .split(/[,\s]+/)
+      .filter(Boolean),
+  );
+  const canonical = attributeValue(html, "link", "href", "rel", "canonical");
+  const h1 = elementText(html, "h1");
+  const pageText = textContent(html);
+
+  if (!title || !description || !h1) {
+    addFinding("critical", "page intent", "Title, description, or H1 is missing.", relativePath);
+  }
+  if (
+    !robotsDirectives.has("index") ||
+    !robotsDirectives.has("follow") ||
+    robotsDirectives.has("noindex") ||
+    robotsDirectives.has("nofollow")
+  ) {
+    addFinding("critical", "indexation", "Page is not explicitly index,follow.", relativePath);
+  }
+  if (canonical !== expectedUrl) {
+    addFinding("critical", "indexation", `Canonical should be ${expectedUrl}.`, relativePath);
+  }
+
+  titles.set(title, [...(titles.get(title) || []), relativePath]);
+  descriptions.set(description, [
+    ...(descriptions.get(description) || []),
+    relativePath,
+  ]);
+
+  if (title.length > 60) {
+    addFinding(
+      "low",
+      "titles",
+      `Title is ${title.length} characters and may truncate in some results.`,
+      relativePath,
+    );
+  }
+  if (description.length > 160) {
+    addFinding(
+      "low",
+      "titles",
+      `Description is ${description.length} characters and may truncate in some results.`,
+      relativePath,
+    );
+  }
+
+  try {
+    const graphs = jsonLd(html);
+    if (graphs.length === 0 || !graphs.every((graph) => graph["@context"] === "https://schema.org")) {
+      addFinding("high", "structured data", "Schema.org JSON-LD is missing.", relativePath);
+    }
+  } catch (error) {
+    addFinding(
+      "critical",
+      "structured data",
+      `JSON-LD does not parse: ${error.message}`,
+      relativePath,
+    );
+  }
+
+  for (const match of html.matchAll(/<a\b[^>]*href="([^"]+)"/gi)) {
+    try {
+      const linkedUrl = new URL(match[1], expectedUrl);
+      const normalizedUrl = linkedUrl.href.split("#")[0];
+      if (normalizedUrl !== expectedUrl && incomingLinks.has(normalizedUrl)) {
+        incomingLinks.set(normalizedUrl, incomingLinks.get(normalizedUrl) + 1);
+      }
+
+      if (
+        linkedUrl.origin === siteUrl.origin &&
+        linkedUrl.pathname.startsWith(siteUrl.pathname)
+      ) {
+        const relativeUrlPath = decodeURIComponent(
+          linkedUrl.pathname.slice(siteUrl.pathname.length),
+        );
+        const targetPath =
+          relativeUrlPath === "" || relativeUrlPath.endsWith("/")
+            ? `${relativeUrlPath}index.html`
+            : relativeUrlPath;
+        const key = `${targetPath}${linkedUrl.hash}`;
+        const target = internalTargets.get(key) || {
+          fragment: decodeURIComponent(linkedUrl.hash.slice(1)),
+          sources: new Set(),
+          targetPath,
+        };
+        target.sources.add(relativePath);
+        internalTargets.set(key, target);
+      }
+    } catch {
+      addFinding("medium", "internal links", `Invalid link ${match[1]}.`, relativePath);
+    }
+  }
+
+  if (!isHome) {
+    const loop = loops.find((candidate) => relativePath.includes(candidate.slug));
+    const detailsIndex = html.indexOf('<details class="detail-more">');
+    const ledeIndex = html.indexOf('class="detail-lede"');
+    const promptIndex = html.indexOf("data-prompt");
+    const verifyIndex = html.indexOf('class="verification-card"');
+
+    if (
+      detailsIndex < 0 ||
+      ledeIndex < 0 ||
+      promptIndex < 0 ||
+      verifyIndex < 0 ||
+      Math.max(ledeIndex, promptIndex, verifyIndex) > detailsIndex
+    ) {
+      addFinding(
+        "high",
+        "answer-first content",
+        "Description, prompt, and verification must appear before collapsed guidance.",
+        relativePath,
+      );
+    }
+
+    if (loop.sourceUrl) {
+      if (!html.includes(`href="${loop.sourceUrl}"`) || !html.includes("isBasedOn")) {
+        addFinding(
+          "high",
+          "source citations",
+          "Contributed loop is missing its visible source link or isBasedOn schema.",
+          relativePath,
+        );
+      }
+    } else if (!pageText.includes(`Contributed by ${loop.author}`)) {
+      addFinding(
+        "medium",
+        "source citations",
+        "Original loop is missing visible contributor attribution.",
+        relativePath,
+      );
+    }
+  }
+}
+
+for (const { fragment, sources, targetPath } of internalTargets.values()) {
+  const targetFile = path.resolve(siteRoot, targetPath);
+  const sourceList = [...sources].join(", ");
+
+  if (!targetFile.startsWith(`${siteRoot}${path.sep}`)) {
+    addFinding(
+      "critical",
+      "internal links",
+      `Internal link escapes the site root: ${targetPath}.`,
+      sourceList,
+    );
+    continue;
+  }
+
+  try {
+    await access(targetFile);
+  } catch {
+    addFinding(
+      "critical",
+      "internal links",
+      `Internal link target does not exist: ${targetPath}.`,
+      sourceList,
+    );
+    continue;
+  }
+
+  if (fragment && targetPath.endsWith(".html")) {
+    const targetHtml = pages.get(targetPath) || (await readFile(targetFile, "utf8"));
+    const fragmentPattern = new RegExp(
+      `(?:id|name)=["']${escapePattern(fragment)}["']`,
+      "i",
+    );
+    if (!fragmentPattern.test(targetHtml)) {
+      addFinding(
+        "high",
+        "internal links",
+        `Internal fragment does not exist: ${targetPath}#${fragment}.`,
+        sourceList,
+      );
+    }
+  }
+}
+
+for (const [title, titlePages] of titles) {
+  if (titlePages.length > 1) {
+    addFinding("high", "titles", `Duplicate title: ${title}.`, titlePages.join(", "));
+  }
+}
+
+for (const [description, descriptionPages] of descriptions) {
+  if (descriptionPages.length > 1) {
+    addFinding(
+      "high",
+      "page intent",
+      `Duplicate description: ${description}.`,
+      descriptionPages.join(", "),
+    );
+  }
+}
+
+for (const [url, count] of incomingLinks) {
+  if (url !== site.baseUrl && count === 0) {
+    addFinding("high", "internal links", `No internal link points to ${url}.`);
+  }
+}
+
+for (const item of benchmark.queries) {
+  const html = pages.get(item.expectedPath);
+  if (!html) {
+    addFinding(
+      "critical",
+      "priority queries",
+      `${item.id} has no mapped page at ${item.expectedPath}.`,
+    );
+    continue;
+  }
+
+  const normalizedPage = normalize(textContent(html));
+  for (const phrase of item.requiredPhrases) {
+    if (!normalizedPage.includes(normalize(phrase))) {
+      addFinding(
+        "high",
+        "priority queries",
+        `${item.id} is mapped to ${item.expectedPath}, but the page does not clearly answer with “${phrase}”.`,
+        item.expectedPath,
+      );
+    }
+  }
+}
+
+for (const loop of loops) {
+  const relativePath = `loops/${loop.slug}/index.html`;
+  const html = pages.get(relativePath);
+  const expectedPhrases = [loop.title.replace(/^The /, ""), loop.description];
+  if (!expectedPhrases.every((phrase) => normalize(textContent(html)).includes(normalize(phrase)))) {
+    addFinding(
+      "high",
+      "priority queries",
+      `${loop.seoTitle} does not map to a clear answer-ready detail page.`,
+      relativePath,
+    );
+  }
+}
+
+const severityOrder = { critical: 0, high: 1, medium: 2, low: 3 };
+findings.sort(
+  (left, right) =>
+    severityOrder[left.severity] - severityOrder[right.severity] ||
+    left.area.localeCompare(right.area) ||
+    (left.page || "").localeCompare(right.page || ""),
+);
+
+const summary = {
+  pages: pages.size,
+  priorityQueries: benchmark.queries.length + loops.length,
+  findings: {
+    critical: findings.filter(({ severity }) => severity === "critical").length,
+    high: findings.filter(({ severity }) => severity === "high").length,
+    medium: findings.filter(({ severity }) => severity === "medium").length,
+    low: findings.filter(({ severity }) => severity === "low").length,
+  },
+};
+
+if (process.argv.includes("--json")) {
+  console.log(JSON.stringify({ summary, findings }, null, 2));
+} else {
+  console.log(
+    `SEO/GEO audit: ${summary.pages} pages, ${summary.priorityQueries} priority-query mappings`,
+  );
+  console.log(
+    `Findings: ${summary.findings.critical} critical, ${summary.findings.high} high, ${summary.findings.medium} medium, ${summary.findings.low} low`,
+  );
+  for (const finding of findings) {
+    console.log(
+      `- ${finding.severity.toUpperCase()} [${finding.area}]${finding.page ? ` ${finding.page}:` : ""} ${finding.message}`,
+    );
+  }
+}
+
+if (summary.findings.critical > 0 || summary.findings.high > 0) {
+  process.exitCode = 1;
+}

--- a/scripts/build-loop-pages.mjs
+++ b/scripts/build-loop-pages.mjs
@@ -246,7 +246,7 @@ ${structuredData(loop)}
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -117,6 +117,9 @@ const structuredData = JSON.parse(structuredDataMatch[1]);
 const collection = structuredData["@graph"].find(
   (item) => item["@type"] === "CollectionPage",
 );
+const agentLoopTerm = structuredData["@graph"].find(
+  (item) => item["@type"] === "DefinedTerm",
+);
 const slugs = new Set(loops.map((loop) => loop.slug));
 const titles = new Set(loops.map((loop) => loop.title));
 const prompts = new Set(loops.map((loop) => loop.prompt));
@@ -154,6 +157,19 @@ const requestedConceptSlugs = [
 
 assert.equal(collection.mainEntity.numberOfItems, loops.length);
 assert.equal(collection.mainEntity.itemListElement.length, loops.length);
+assert.equal(
+  collection.about["@id"],
+  `${siteMeta.baseUrl}#ai-agent-loop`,
+);
+assert.equal(agentLoopTerm.name, "AI agent loop");
+assert.equal(
+  agentLoopTerm.url,
+  `${siteMeta.baseUrl}#what-is-an-ai-agent-loop`,
+);
+assert.deepEqual(agentLoopTerm.sameAs, [
+  "https://code.claude.com/docs/en/agent-sdk/agent-loop",
+  "https://arxiv.org/abs/2210.03629",
+]);
 assert.equal(loops.length, 29);
 assert.equal(slugs.size, loops.length);
 assert.equal(titles.size, loops.length);
@@ -329,6 +345,8 @@ for (const [index, loop] of loops.entries()) {
   assert(!page.includes("<h2>Topics</h2>"));
   assert(page.includes("Related loops"));
   assert(!page.includes("<dt>Type</dt>"));
+  assert(page.includes('href="../../#what-is-an-ai-agent-loop">What is a loop?</a>'));
+  assert(!page.includes('href="../../#tips"'));
   assert(page.includes('data-copy-root'));
   assert.equal((page.match(/data-here-now-credit/g) || []).length, 2);
   assert.equal((page.match(/https:\/\/here\.now\/r\/signals/g) || []).length, 2);
@@ -446,13 +464,19 @@ assert(!html.includes('data-type='));
 assert(!html.includes('class="cell-type"'));
 assert(!html.includes("type-badge"));
 assert(!html.includes('<th scope="col">Type</th>'));
-assert(html.includes("./styles.css?v=20260619-pagination"));
+assert(html.includes("./styles.css?v=20260619-answer-first"));
 assert(html.includes("./script.js?v=20260619-pagination"));
 assert(html.includes('id="library-pagination"'));
 assert(html.includes('aria-label="Loop pages"'));
 assert(html.includes('id="pagination-previous"'));
 assert(html.includes('id="pagination-status"'));
 assert(html.includes('id="pagination-next"'));
+assert(html.includes('id="what-is-an-ai-agent-loop"'));
+assert(html.includes("What is an AI agent loop?"));
+assert(html.includes("An AI agent loop is a repeatable workflow"));
+assert(html.includes("explicit success or stop condition"));
+assert(html.includes("Claude Agent SDK loop documentation"));
+assert(html.includes("the ReAct paper"));
 assert(html.includes('id="agent-skill"'));
 assert(html.includes("Use Loop Library in your coding agent."));
 assert(
@@ -523,6 +547,7 @@ assert(css.includes(".pagination-button:disabled"));
 assert(css.includes("scroll-margin-top: 80px"));
 assert(css.includes(".pagination-button,\n  .pagination-status"));
 assert(css.includes(".skill-promo"));
+assert(css.includes(".answer-capsule"));
 assert(css.includes(".skill-copy-button"));
 assert(css.includes("border-left: 5px solid var(--orange)"));
 assert(css.includes("background: var(--surface-muted)"));

--- a/scripts/seo-geo-query-benchmark.json
+++ b/scripts/seo-geo-query-benchmark.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "recording": {
+    "locale": "en-US",
+    "location": "United States",
+    "searchEngines": ["Google Search", "DuckDuckGo", "Bing"],
+    "answerEngines": ["Google AI Overview", "ChatGPT Search", "Duck.ai"],
+    "notes": "Run the same queries without personalization where the engine supports it. Record blocked engines instead of changing the query."
+  },
+  "queries": [
+    {
+      "id": "generic-discovery",
+      "query": "AI agent loop library reusable prompts",
+      "expectedPath": "index.html",
+      "requiredPhrases": ["AI agent", "loop", "prompts"]
+    },
+    {
+      "id": "generic-definition",
+      "query": "what is an AI agent loop",
+      "expectedPath": "index.html",
+      "requiredPhrases": ["What is an AI agent loop?", "repeatable", "stop condition"]
+    },
+    {
+      "id": "detail-intent",
+      "query": "repository cleanup loop for coding agents",
+      "expectedPath": "loops/repository-cleanup-loop/index.html",
+      "requiredPhrases": ["repository cleanup loop", "coding agents"]
+    },
+    {
+      "id": "brand-entity",
+      "query": "Forward Future Loop Library",
+      "expectedPath": "index.html",
+      "requiredPhrases": ["Forward Future", "Loop Library"]
+    }
+  ]
+}

--- a/site/index.html
+++ b/site/index.html
@@ -116,7 +116,7 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.md"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260619-pagination" />
+    <link rel="stylesheet" href="./styles.css?v=20260619-answer-first" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -158,6 +158,9 @@
             },
             "isPartOf": {
               "@id": "https://signals.forwardfuture.ai/loop-library/#website"
+            },
+            "about": {
+              "@id": "https://signals.forwardfuture.ai/loop-library/#ai-agent-loop"
             },
             "mainEntity": {
               "@type": "ItemList",
@@ -339,6 +342,17 @@
                 }
               ]
             }
+          },
+          {
+            "@type": "DefinedTerm",
+            "@id": "https://signals.forwardfuture.ai/loop-library/#ai-agent-loop",
+            "name": "AI agent loop",
+            "description": "A repeatable workflow in which an AI agent acts on a goal, checks the result, and continues until it reaches an explicit success or stop condition.",
+            "url": "https://signals.forwardfuture.ai/loop-library/#what-is-an-ai-agent-loop",
+            "sameAs": [
+              "https://code.claude.com/docs/en/agent-sdk/agent-loop",
+              "https://arxiv.org/abs/2210.03629"
+            ]
           }
         ]
       }
@@ -415,6 +429,48 @@
             Copy prompts for engineering, research, evaluation, and operations.
             Each one includes clear checks and tells the agent when to stop.
           </p>
+
+          <section
+            class="answer-capsule"
+            aria-labelledby="what-is-an-ai-agent-loop"
+          >
+            <div>
+              <p class="answer-capsule-kicker">Plain-language definition</p>
+              <h2 id="what-is-an-ai-agent-loop">What is an AI agent loop?</h2>
+            </div>
+            <div class="answer-capsule-copy">
+              <p>
+                <strong>An AI agent loop is a repeatable workflow</strong> in
+                which an agent acts on a goal, checks what happened, and uses
+                that feedback to choose the next step. It stops when an
+                explicit success or stop condition is met.
+              </p>
+              <p>
+                Loop Library turns that pattern into copy-ready prompts with a
+                clear verification check and stopping point.
+              </p>
+              <p class="answer-capsule-sources">
+                Sources:
+                <cite
+                  ><a
+                    href="https://code.claude.com/docs/en/agent-sdk/agent-loop"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Claude Agent SDK loop documentation</a
+                  ></cite
+                >
+                and
+                <cite
+                  ><a
+                    href="https://arxiv.org/abs/2210.03629"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >the ReAct paper</a
+                  ></cite
+                >.
+              </p>
+            </div>
+          </section>
         </div>
 
         <section

--- a/site/loops/100-percent-test-coverage-loop/index.html
+++ b/site/loops/100-percent-test-coverage-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/architecture-satisfaction-loop/index.html
+++ b/site/loops/architecture-satisfaction-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/autonomy-loop/index.html
+++ b/site/loops/autonomy-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/boeing-747-benchmark/index.html
+++ b/site/loops/boeing-747-benchmark/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/clodex-adversarial-review-loop/index.html
+++ b/site/loops/clodex-adversarial-review-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/codex-completion-contract-loop/index.html
+++ b/site/loops/codex-completion-contract-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/customer-ai-deployment-loop/index.html
+++ b/site/loops/customer-ai-deployment-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/devils-advocate-design-loop/index.html
+++ b/site/loops/devils-advocate-design-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/exhaustive-logging-coverage-loop/index.html
+++ b/site/loops/exhaustive-logging-coverage-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/fresh-clone-loop/index.html
+++ b/site/loops/fresh-clone-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/full-product-evaluation-loop/index.html
+++ b/site/loops/full-product-evaluation-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/infinite-clickbait-loop/index.html
+++ b/site/loops/infinite-clickbait-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/loop-harness-verification-loop/index.html
+++ b/site/loops/loop-harness-verification-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/nightly-changelog-sweep/index.html
+++ b/site/loops/nightly-changelog-sweep/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/overnight-docs-sweep/index.html
+++ b/site/loops/overnight-docs-sweep/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/post-release-baseline-loop/index.html
+++ b/site/loops/post-release-baseline-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/product-update-podcast-loop/index.html
+++ b/site/loops/product-update-podcast-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/production-data-cleanup-loop/index.html
+++ b/site/loops/production-data-cleanup-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/production-error-sweep/index.html
+++ b/site/loops/production-error-sweep/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/quality-streak-loop/index.html
+++ b/site/loops/quality-streak-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/repository-cleanup-loop/index.html
+++ b/site/loops/repository-cleanup-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/revolve-self-improvement-loop/index.html
+++ b/site/loops/revolve-self-improvement-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/self-improving-champion-loop/index.html
+++ b/site/loops/self-improving-champion-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/seo-geo-visibility-loop/index.html
+++ b/site/loops/seo-geo-visibility-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/stale-safe-batch-release-loop/index.html
+++ b/site/loops/stale-safe-batch-release-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/sub-50ms-page-load-loop/index.html
+++ b/site/loops/sub-50ms-page-load-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/test-suite-speed-loop/index.html
+++ b/site/loops/test-suite-speed-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/ticket-to-pr-ready-loop/index.html
+++ b/site/loops/ticket-to-pr-ready-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/war-loops-frontend-designer/index.html
+++ b/site/loops/war-loops-frontend-designer/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#tips">Best practices</a>
+        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/styles.css
+++ b/site/styles.css
@@ -380,6 +380,59 @@ code {
   max-width: 920px;
 }
 
+.answer-capsule {
+  display: grid;
+  gap: clamp(20px, 4vw, 44px);
+  margin-top: 26px;
+  padding: 24px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  grid-template-columns: minmax(220px, 0.75fr) minmax(0, 1.25fr);
+}
+
+.answer-capsule h2 {
+  margin-bottom: 0;
+  font-size: clamp(1.55rem, 2.5vw, 2.15rem);
+  font-weight: 800;
+  letter-spacing: -0.045em;
+  line-height: 1;
+}
+
+.answer-capsule-kicker,
+.answer-capsule-sources {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  line-height: 1.45;
+}
+
+.answer-capsule-kicker {
+  margin-bottom: 8px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.answer-capsule-copy > p {
+  margin-bottom: 10px;
+}
+
+.answer-capsule-copy > p:last-child {
+  margin-bottom: 0;
+}
+
+.answer-capsule-sources a {
+  color: inherit;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.answer-capsule-sources a:hover,
+.answer-capsule-sources a:focus-visible {
+  color: var(--ink);
+  text-decoration-thickness: 2px;
+}
+
 .skill-promo {
   display: grid;
   align-items: center;
@@ -1468,6 +1521,11 @@ code {
 
   .skill-promo {
     align-items: start;
+    gap: 14px;
+    grid-template-columns: 1fr;
+  }
+
+  .answer-capsule {
     gap: 14px;
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## What changed

- add a deterministic SEO/GEO crawler and frozen query benchmark corpus
- add an answer-first AI agent loop definition with visible primary citations and `DefinedTerm` schema
- repair the broken `#tips` navigation link across all generated detail pages
- enforce the audit in CI and document the benchmark results

## Why

The homepage did not clearly answer the generic definition intent, and all 29 detail pages linked to a missing fragment. Those gaps weakened answer-engine retrieval and internal crawl quality.

## Impact

Every priority query now maps to an answer-ready page. The same local crawl moves from 3 high findings to 0 critical, 0 high, and 0 medium findings; eight low snippet-length warnings remain.

## Validation

- `node scripts/audit-seo-geo.mjs`
- `node scripts/check.mjs`
- `npm --prefix worker run check` (12 tests)
- 30 social page screenshots validated
- here.now branding validator: 60 credits across 30 pages
- `git diff --check`
- autoreview clean with no accepted/actionable findings