### PR TITLE
[codex] Remove homepage loop definition block

### DIFF
--- a/scripts/build-loop-pages.mjs
+++ b/scripts/build-loop-pages.mjs
@@ -246,7 +246,7 @@ ${structuredData(loop)}
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -183,7 +183,7 @@ assert.equal(
 assert.equal(agentLoopTerm.name, "AI agent loop");
 assert.equal(
   agentLoopTerm.url,
-  `${siteMeta.baseUrl}#what-is-an-ai-agent-loop`,
+  `${siteMeta.baseUrl}learn/`,
 );
 assert.deepEqual(agentLoopTerm.sameAs, [
   "https://code.claude.com/docs/en/agent-sdk/agent-loop",
@@ -388,7 +388,7 @@ for (const [index, loop] of loops.entries()) {
   assert(!page.includes("<h2>Topics</h2>"));
   assert(page.includes("Related loops"));
   assert(!page.includes("<dt>Type</dt>"));
-  assert(page.includes('href="../../#what-is-an-ai-agent-loop">What is a loop?</a>'));
+  assert(page.includes('href="../../learn/">What is a loop?</a>'));
   assert(!page.includes('href="../../#tips"'));
   assert(page.includes('data-copy-root'));
   assert.equal((page.match(/data-here-now-credit/g) || []).length, 2);
@@ -521,12 +521,9 @@ assert(html.includes('aria-label="Loop pages"'));
 assert(html.includes('id="pagination-previous"'));
 assert(html.includes('id="pagination-status"'));
 assert(html.includes('id="pagination-next"'));
-assert(html.includes('id="what-is-an-ai-agent-loop"'));
-assert(html.includes("What is an AI agent loop?"));
-assert(html.includes("An AI agent loop is a repeatable workflow"));
-assert(html.includes("explicit success or stop condition"));
-assert(html.includes("Claude Agent SDK loop documentation"));
-assert(html.includes("the ReAct paper"));
+assert(!html.includes('class="answer-capsule"'));
+assert(!html.includes("Plain-language definition"));
+assert(!html.includes("What is an AI agent loop?"));
 assert(html.includes('id="agent-skill"'));
 assert(html.includes("Use Loop Library in your coding agent."));
 assert(
@@ -627,7 +624,7 @@ assert(css.includes(".pagination-button:disabled"));
 assert(css.includes("scroll-margin-top: 80px"));
 assert(css.includes(".pagination-button,\n  .pagination-status"));
 assert(css.includes(".skill-promo"));
-assert(css.includes(".answer-capsule"));
+assert(!css.includes(".answer-capsule"));
 assert(css.includes(".skill-copy-button"));
 assert(css.includes("border-left: 5px solid var(--orange)"));
 assert(css.includes("background: var(--surface-muted)"));

--- a/scripts/seo-geo-query-benchmark.json
+++ b/scripts/seo-geo-query-benchmark.json
@@ -17,8 +17,8 @@
     {
       "id": "generic-definition",
       "query": "what is an AI agent loop",
-      "expectedPath": "index.html",
-      "requiredPhrases": ["What is an AI agent loop?", "repeatable", "stop condition"]
+      "expectedPath": "learn/index.html",
+      "requiredPhrases": ["How agent loops work", "task with a check", "continues or stops"]
     },
     {
       "id": "detail-intent",

--- a/site/index.html
+++ b/site/index.html
@@ -348,7 +348,7 @@
             "@id": "https://signals.forwardfuture.ai/loop-library/#ai-agent-loop",
             "name": "AI agent loop",
             "description": "A repeatable workflow in which an AI agent acts on a goal, checks the result, and continues until it reaches an explicit success or stop condition.",
-            "url": "https://signals.forwardfuture.ai/loop-library/#what-is-an-ai-agent-loop",
+            "url": "https://signals.forwardfuture.ai/loop-library/learn/",
             "sameAs": [
               "https://code.claude.com/docs/en/agent-sdk/agent-loop",
               "https://arxiv.org/abs/2210.03629"
@@ -431,47 +431,6 @@
             Each one includes clear checks and tells the agent when to stop.
           </p>
 
-          <section
-            class="answer-capsule"
-            aria-labelledby="what-is-an-ai-agent-loop"
-          >
-            <div>
-              <p class="answer-capsule-kicker">Plain-language definition</p>
-              <h2 id="what-is-an-ai-agent-loop">What is an AI agent loop?</h2>
-            </div>
-            <div class="answer-capsule-copy">
-              <p>
-                <strong>An AI agent loop is a repeatable workflow</strong> in
-                which an agent acts on a goal, checks what happened, and uses
-                that feedback to choose the next step. It stops when an
-                explicit success or stop condition is met.
-              </p>
-              <p>
-                Loop Library turns that pattern into copy-ready prompts with a
-                clear verification check and stopping point.
-              </p>
-              <p class="answer-capsule-sources">
-                Sources:
-                <cite
-                  ><a
-                    href="https://code.claude.com/docs/en/agent-sdk/agent-loop"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    >Claude Agent SDK loop documentation</a
-                  ></cite
-                >
-                and
-                <cite
-                  ><a
-                    href="https://arxiv.org/abs/2210.03629"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    >the ReAct paper</a
-                  ></cite
-                >.
-              </p>
-            </div>
-          </section>
         </div>
 
         <section

--- a/site/loops/100-percent-test-coverage-loop/index.html
+++ b/site/loops/100-percent-test-coverage-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/architecture-satisfaction-loop/index.html
+++ b/site/loops/architecture-satisfaction-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/autonomy-loop/index.html
+++ b/site/loops/autonomy-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/boeing-747-benchmark/index.html
+++ b/site/loops/boeing-747-benchmark/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/clodex-adversarial-review-loop/index.html
+++ b/site/loops/clodex-adversarial-review-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/codex-completion-contract-loop/index.html
+++ b/site/loops/codex-completion-contract-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/customer-ai-deployment-loop/index.html
+++ b/site/loops/customer-ai-deployment-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/devils-advocate-design-loop/index.html
+++ b/site/loops/devils-advocate-design-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/exhaustive-logging-coverage-loop/index.html
+++ b/site/loops/exhaustive-logging-coverage-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/fresh-clone-loop/index.html
+++ b/site/loops/fresh-clone-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/full-product-evaluation-loop/index.html
+++ b/site/loops/full-product-evaluation-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/infinite-clickbait-loop/index.html
+++ b/site/loops/infinite-clickbait-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/loop-harness-verification-loop/index.html
+++ b/site/loops/loop-harness-verification-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/nightly-changelog-sweep/index.html
+++ b/site/loops/nightly-changelog-sweep/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/overnight-docs-sweep/index.html
+++ b/site/loops/overnight-docs-sweep/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/post-release-baseline-loop/index.html
+++ b/site/loops/post-release-baseline-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/product-update-podcast-loop/index.html
+++ b/site/loops/product-update-podcast-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/production-data-cleanup-loop/index.html
+++ b/site/loops/production-data-cleanup-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/production-error-sweep/index.html
+++ b/site/loops/production-error-sweep/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/quality-streak-loop/index.html
+++ b/site/loops/quality-streak-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/repository-cleanup-loop/index.html
+++ b/site/loops/repository-cleanup-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/revolve-self-improvement-loop/index.html
+++ b/site/loops/revolve-self-improvement-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/self-improving-champion-loop/index.html
+++ b/site/loops/self-improving-champion-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/seo-geo-visibility-loop/index.html
+++ b/site/loops/seo-geo-visibility-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/stale-safe-batch-release-loop/index.html
+++ b/site/loops/stale-safe-batch-release-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/sub-50ms-page-load-loop/index.html
+++ b/site/loops/sub-50ms-page-load-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/test-suite-speed-loop/index.html
+++ b/site/loops/test-suite-speed-loop/index.html
@@ -150,7 +150,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/ticket-to-pr-ready-loop/index.html
+++ b/site/loops/ticket-to-pr-ready-loop/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/loops/war-loops-frontend-designer/index.html
+++ b/site/loops/war-loops-frontend-designer/index.html
@@ -151,7 +151,7 @@
 
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../../#library">All loops</a>
-        <a href="../../#what-is-an-ai-agent-loop">What is a loop?</a>
+        <a href="../../learn/">What is a loop?</a>
         <button
           class="theme-toggle"
           id="theme-toggle"

--- a/site/styles.css
+++ b/site/styles.css
@@ -387,59 +387,6 @@ code {
   max-width: 920px;
 }
 
-.answer-capsule {
-  display: grid;
-  gap: clamp(20px, 4vw, 44px);
-  margin-top: 26px;
-  padding: 24px 0;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-  grid-template-columns: minmax(220px, 0.75fr) minmax(0, 1.25fr);
-}
-
-.answer-capsule h2 {
-  margin-bottom: 0;
-  font-size: clamp(1.55rem, 2.5vw, 2.15rem);
-  font-weight: 800;
-  letter-spacing: -0.045em;
-  line-height: 1;
-}
-
-.answer-capsule-kicker,
-.answer-capsule-sources {
-  color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  line-height: 1.45;
-}
-
-.answer-capsule-kicker {
-  margin-bottom: 8px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.answer-capsule-copy > p {
-  margin-bottom: 10px;
-}
-
-.answer-capsule-copy > p:last-child {
-  margin-bottom: 0;
-}
-
-.answer-capsule-sources a {
-  color: inherit;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
-}
-
-.answer-capsule-sources a:hover,
-.answer-capsule-sources a:focus-visible {
-  color: var(--ink);
-  text-decoration-thickness: 2px;
-}
-
 .skill-promo {
   display: grid;
   align-items: center;
@@ -1673,11 +1620,6 @@ code {
 
   .skill-promo {
     align-items: start;
-    gap: 14px;
-    grid-template-columns: 1fr;
-  }
-
-  .answer-capsule {
     gap: 14px;
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## What changed

- removed the plain-language AI agent loop definition block from the homepage
- redirected loop-page “What is a loop?” links and structured metadata to the existing Learn guide
- moved the generic definition SEO benchmark to that guide and removed the unused component styles

## Why

The definition block shown on the homepage is no longer wanted. Redirecting its dependent links avoids broken anchors while preserving the dedicated explanatory content on `/learn/`.

## Validation

- full generated-site build and syntax checks
- `node scripts/audit-seo-geo.mjs` (0 critical/high/medium findings)
- `node scripts/check.mjs`
- `npm --prefix worker run check` (12/12 tests)
- desktop and mobile browser checks with no horizontal overflow
- autoreview clean; no accepted/actionable findings