### PR TITLE
[codex] Feature top loops and simplify library rows

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import {
   categories,
+  featuredLoopSlugs,
   getLoopCategory,
   loops,
   site as siteMeta,
@@ -124,6 +125,8 @@ const agentLoopTerm = structuredData["@graph"].find(
 );
 const slugs = new Set(loops.map((loop) => loop.slug));
 const loopBySlug = new Map(loops.map((loop) => [loop.slug, loop]));
+const featuredLoops = featuredLoopSlugs.map((slug) => loopBySlug.get(slug));
+const featuredSlugSet = new Set(featuredLoopSlugs);
 const titles = new Set(loops.map((loop) => loop.title));
 const prompts = new Set(loops.map((loop) => loop.prompt));
 const categorySlugs = new Set(categories.map((category) => category.slug));
@@ -197,6 +200,9 @@ assert.deepEqual(agentLoopTerm.sameAs, [
 ]);
 assert.equal(loops.length, 31);
 assert.equal(slugs.size, loops.length);
+assert.equal(featuredLoopSlugs.length, 3);
+assert.equal(new Set(featuredLoopSlugs).size, featuredLoopSlugs.length);
+assert(featuredLoops.every(Boolean));
 assert.equal(titles.size, loops.length);
 assert.equal(prompts.size, loops.length);
 assert(
@@ -265,6 +271,9 @@ assert(!skillSource.includes("Add an escalation owner"));
 assert(skillInterface.includes('display_name: "Loop Library"'));
 assert(skillInterface.includes("$loop-library"));
 
+const loopTableIndex = html.indexOf('<table class="loop-table">');
+assert(loopTableIndex >= 0);
+
 for (const [index, loop] of loops.entries()) {
   const url = `${siteMeta.baseUrl}loops/${loop.slug}/`;
   const imageUrl = `${siteMeta.baseUrl}assets/social/${loop.slug}-${siteMeta.socialImageVersion}.${siteMeta.socialImageExtension}`;
@@ -272,7 +281,7 @@ for (const [index, loop] of loops.entries()) {
   const page = loopPages[index];
   const listItem = collection.mainEntity.itemListElement[index];
   const homepageHref = `href="./loops/${loop.slug}/"`;
-  const homepageHrefIndex = html.indexOf(homepageHref);
+  const homepageHrefIndex = html.indexOf(homepageHref, loopTableIndex);
   const rowStart = html.lastIndexOf("<tr", homepageHrefIndex);
   const rowEnd = html.indexOf("</tr>", homepageHrefIndex);
   const homepageRow = html.slice(rowStart, rowEnd);
@@ -322,7 +331,7 @@ for (const [index, loop] of loops.entries()) {
       `<p class="loop-summary">${escapeHtml(loop.summary)}</p>`,
     ),
   );
-  assert(homepageRow.includes(`<td class="cell-number">${loop.number}</td>`));
+  assert(!homepageRow.includes('class="cell-number"'));
   assert(homepageRow.includes(`data-category="${category.slug}"`));
   assert(
     homepageRow.includes(
@@ -330,6 +339,13 @@ for (const [index, loop] of loops.entries()) {
     ),
   );
   assert(homepageRow.includes(loop.author));
+  if (featuredSlugSet.has(loop.slug)) {
+    assert(homepageRow.includes('data-featured="true"'));
+    assert(homepageRow.includes('<span class="loop-featured">Featured</span>'));
+  } else {
+    assert(!homepageRow.includes('data-featured="true"'));
+    assert(!homepageRow.includes('class="loop-featured"'));
+  }
   assert(
     homepageRow.includes(
       `<span class="loop-attribution">By ${escapeHtml(loop.author)}</span>`,
@@ -488,6 +504,24 @@ assert.equal((html.match(/class="loop-meta"/g) || []).length, loops.length);
 assert.equal((html.match(/class="loop-summary"/g) || []).length, loops.length);
 assert.equal((html.match(/class="loop-attribution"/g) || []).length, loops.length);
 assert(html.includes('class="loop-table"'));
+assert(!html.includes('<th scope="col">ID</th>'));
+assert(!html.includes('<th scope="col">No.</th>'));
+assert(!html.includes('class="cell-number"'));
+assert(!html.includes('class="cell-check"'));
+assert(!html.includes("Verify / stop"));
+assert.equal(
+  (html.match(/<span>Copy loop<\/span>/g) || []).length,
+  loops.length,
+);
+assert.equal(
+  (html.match(/data-featured="true"/g) || []).length,
+  featuredLoops.length,
+);
+assert.equal(
+  (html.match(/class="loop-featured"/g) || []).length,
+  featuredLoops.length,
+);
+assert(!html.includes('class="featured-loops"'));
 assert(!html.includes('class="cell-attribution"'));
 assert(!html.includes('<th scope="col">Attribution</th>'));
 assert(!html.includes('class="loop-diagram"'));
@@ -518,8 +552,8 @@ assert(!html.includes('data-type='));
 assert(!html.includes('class="cell-type"'));
 assert(!html.includes("type-badge"));
 assert(!html.includes('<th scope="col">Type</th>'));
-assert(html.includes("./styles.css?v=20260619-learn-page"));
-assert(html.includes("./script.js?v=20260619-pagination"));
+assert(html.includes("./styles.css?v=20260619-row-padding"));
+assert(html.includes("./script.js?v=20260619-no-numbering"));
 assert(html.includes('href="./learn/"'));
 assert(!html.includes('class="loop-guide"'));
 assert(!html.includes("A useful loop specifies:"));
@@ -626,6 +660,12 @@ assert(css.includes(".category-filter.is-active"));
 assert(css.includes(".loop-category"));
 assert(css.includes(".loop-meta"));
 assert(css.includes(".loop-summary"));
+assert(!css.includes(".cell-number"));
+assert(css.includes(".cell-loop .loop-summary {\n  display: none;\n}"));
+assert(css.includes(".loop-prompt-toggle"));
+assert(css.includes("-webkit-line-clamp: 3"));
+assert(css.includes("-webkit-line-clamp: 4"));
+assert(!css.includes(".cell-check"));
 assert(css.includes(".loop-attribution"));
 assert(!css.includes(".cell-attribution"));
 assert(css.includes(".pagination"));
@@ -633,6 +673,8 @@ assert(css.includes(".pagination-button:disabled"));
 assert(css.includes("scroll-margin-top: 80px"));
 assert(css.includes(".pagination-button,\n  .pagination-status"));
 assert(css.includes(".skill-promo"));
+assert(css.includes(".library-hero"));
+assert(css.includes(".loop-featured"));
 assert(!css.includes(".answer-capsule"));
 assert(css.includes(".skill-copy-button"));
 assert(css.includes("border-left: 5px solid var(--orange)"));
@@ -676,7 +718,20 @@ assert(script.includes("bytes[6] = (bytes[6] & 0x0f) | 0x40"));
 assert(script.includes("bytes[8] = (bytes[8] & 0x3f) | 0x80"));
 assert(!script.includes("./.herenow/data/"));
 assert(script.includes('document.querySelectorAll(".loop-row")'));
+assert(!script.includes('querySelector(".cell-number")'));
+assert(script.includes('querySelector(".loop-title-link")'));
+assert(script.includes('b.dataset.featured === "true"'));
+assert(script.includes('a.dataset.featured === "true"'));
+assert(script.includes("loopRows.forEach((row) => loopTableBody.append(row))"));
 assert(script.includes("const PAGE_SIZE = 25"));
+assert(script.includes("const defaultLabel = label?.textContent"));
+assert(script.includes("window.clearTimeout(copyLabelResetTimer)"));
+assert(script.includes("label.textContent = defaultLabel"));
+assert(script.includes('button.textContent = "Show more"'));
+assert(script.includes('button.textContent = nextExpanded ? "Show less" : "Show more"'));
+assert(script.includes('button.setAttribute("aria-controls", prompt.id)'));
+assert(script.includes('button.setAttribute("aria-expanded", "false")'));
+assert(script.includes("window.requestAnimationFrame(syncVisiblePromptToggles)"));
 assert(script.includes("Math.ceil(totalMatches / PAGE_SIZE)"));
 assert(script.includes("matchingRows.slice(pageStart, pageEnd)"));
 assert(script.includes('searchInput.addEventListener("input", resetSearchPage)'));

--- a/scripts/loop-data.mjs
+++ b/scripts/loop-data.mjs
@@ -18,6 +18,12 @@ export const categories = [
   { slug: "design", label: "Design" },
 ];
 
+export const featuredLoopSlugs = [
+  "five-minute-repository-maintainer-loop",
+  "full-product-evaluation-loop",
+  "fresh-clone-loop",
+];
+
 const categorySlugByLabel = new Map([
   ["AI coding agent workflow", "engineering"],
   ["AI repository operations workflow", "engineering"],

--- a/site/index.html
+++ b/site/index.html
@@ -116,7 +116,7 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.md"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260619-learn-page" />
+    <link rel="stylesheet" href="./styles.css?v=20260619-row-padding" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -369,7 +369,7 @@
         ]
       }
     </script>
-    <script src="./script.js?v=20260619-pagination" defer></script>
+    <script src="./script.js?v=20260619-no-numbering" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>
@@ -389,10 +389,7 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="#library">Loops</a>
         <a href="./learn/">Learn</a>
-        <a href="#agent-skill">Install skill</a>
-        <a href="#weekly">Weekly picks</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -435,55 +432,16 @@
 
     <main id="main">
       <section class="library-section page-width" id="library">
-        <div class="library-intro" id="top">
-          <p class="eyebrow">Forward Future field guide</p>
-          <h1>Loop Library</h1>
-          <p class="hero-lede">
-            Copy prompts for engineering, research, evaluation, and operations.
-            Each one includes clear checks and tells the agent when to stop.
-          </p>
-
-        </div>
-
-        <section
-          class="skill-promo"
-          id="agent-skill"
-          aria-labelledby="agent-skill-title"
-        >
-          <div class="skill-promo-copy">
-            <p class="skill-promo-kicker">Agent skill</p>
-            <h2 id="agent-skill-title">
-              Use Loop Library in your coding agent.
-            </h2>
-            <p>
-              Find a published loop or design one directly from your agent.
+        <div class="library-hero" id="top">
+          <div class="library-intro">
+            <h1>Loop Library</h1>
+            <p class="hero-lede">
+              Copy practical AI agent prompts with clear checks and stopping
+              conditions.
             </p>
           </div>
 
-          <div class="skill-promo-actions">
-            <code class="skill-install-command" data-skill-install-command
-              >npx skills add Forward-Future/loop-library --skill loop-library
-              -g</code
-            >
-            <div class="skill-action-row">
-              <button
-                class="skill-copy-button"
-                type="button"
-                data-copy-skill-command
-              >
-                <span>Copy command</span>
-              </button>
-              <a
-                class="skill-github-link"
-                href="https://github.com/Forward-Future/loop-library"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                View repository
-              </a>
-            </div>
-          </div>
-        </section>
+        </div>
 
         <div class="library-controls">
           <label class="search-control">
@@ -568,9 +526,7 @@
             </caption>
             <thead>
               <tr>
-                <th scope="col">No.</th>
                 <th scope="col">Loop</th>
-                <th scope="col">Verify / stop</th>
                 <th scope="col"><span class="sr-only">Action</span></th>
               </tr>
             </thead>
@@ -581,7 +537,6 @@
                 data-category="engineering"
                 data-search="documentation docs sweep audit maintenance anytime on-demand nightly overnight pull request pr matthew berman review codebase"
               >
-                <td class="cell-number">001</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -600,14 +555,9 @@
                     changes, then open a pull request.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Documentation matches the current implementation.</strong>
-                  <span>Finish with a reviewable pull request.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -618,7 +568,6 @@
                 data-category="engineering"
                 data-search="refactor architecture live test autoreview commit progress tmp peter steinberger"
               >
-                <td class="cell-number">002</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -640,14 +589,9 @@
                     /tmp/refactor-{projectname}.md.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The architecture is satisfactory and checks pass.</strong>
-                  <span>Live-test, autoreview, and commit each significant step.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -658,7 +602,6 @@
                 data-category="engineering"
                 data-search="performance speed page load pageload 50ms benchmark optimize profiling routes matthew berman"
               >
-                <td class="cell-number">003</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -680,14 +623,9 @@
                     Continue until every page loads in under 50 ms.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Every page loads in under 50 ms.</strong>
-                  <span>Use the same benchmark and confirm there are no regressions.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -698,7 +636,6 @@
                 data-category="engineering"
                 data-search="production logs errors bugs root cause fix pull request pr matthew berman"
               >
-                <td class="cell-number">004</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -717,14 +654,9 @@
                     If no actionable errors are present, stop without making changes.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Actionable production errors are fixed and verified.</strong>
-                  <span>Finish with a PR, or stop when no actionable errors are present.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -735,7 +667,6 @@
                 data-category="engineering"
                 data-search="tests testing test coverage 100 percent full suite matthew berman"
               >
-                <td class="cell-number">005</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -754,14 +685,9 @@
                     Add tests until we have 100% test coverage.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The full test suite passes at 100% coverage.</strong>
-                  <span>Use the project's coverage report as the source of truth.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -772,7 +698,6 @@
                 data-category="content"
                 data-search="seo geo search generative engine optimization ai answer visibility crawlability indexation indexing metadata titles internal links structured data citations content benchmark matthew berman"
               >
-                <td class="cell-number">006</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Content</span>
@@ -796,14 +721,9 @@
                     high-impact gap left to fix.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Priority pages are indexable, answer-ready, and technically sound.</strong>
-                  <span>The repeatable crawl and query benchmark finds no remaining high-impact gaps.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -814,7 +734,6 @@
                 data-category="engineering"
                 data-search="logging logs observability coverage structured events important paths tests diagnostics matthew berman"
               >
-                <td class="cell-number">007</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -831,14 +750,9 @@
                     every important path produces useful, tested logs.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Every important path emits useful, tested logs.</strong>
-                  <span>Representative success and failure tests prove coverage without exposing sensitive data.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -849,7 +763,6 @@
                 data-category="engineering"
                 data-search="nightly changelog previous day changes users release notes commits pull requests deployments matthew berman"
               >
-                <td class="cell-number">008</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -866,14 +779,9 @@
                     the changelog with anything users should know.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Every user-relevant change from the previous day is accounted for.</strong>
-                  <span>The changelog is updated and validated, or the no-change result is recorded.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -884,7 +792,6 @@
                 data-category="evaluation"
                 data-search="quality streak realistic scenarios regression benchmark failure restart consecutive cases matthew berman"
               >
-                <td class="cell-number">009</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Evaluation</span>
@@ -902,14 +809,9 @@
                     streak. Stop after [N] successful cases in a row.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The latest [N] realistic cases pass in a row.</strong>
-                  <span>Every earlier failure is documented, fixed, and protected by regression and benchmark coverage.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -918,11 +820,12 @@
                 class="loop-row"
                 data-copy-root
                 data-category="evaluation"
+                data-featured="true"
                 data-search="full product evaluation realistic tests test cases scenarios major features capabilities score responses results outcomes success criteria pass fail scoring rubric evidence quality bar rerun matthew berman"
               >
-                <td class="cell-number">010</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
+                    <span class="loop-featured">Featured</span>
                     <span class="loop-category">Evaluation</span>
                     <span class="loop-attribution">By Matthew Berman</span>
                   </div>
@@ -944,14 +847,9 @@
                     original quality bar.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Every one of the [N] scenarios meets the defined quality bar.</strong>
-                  <span>The final evaluated run covers every major capability under the original conditions.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -962,7 +860,6 @@
                 data-category="engineering"
                 data-search="test suite speed performance runtime faster ci coverage behavior optimize matthew berman"
               >
-                <td class="cell-number">011</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -979,14 +876,9 @@
                     without reducing coverage or changing behavior.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The suite is faster with no coverage or behavior regression.</strong>
-                  <span>Repeatable timing, the full passing suite, and the original coverage report prove the result.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -997,7 +889,6 @@
                 data-category="engineering"
                 data-search="repository cleanup local remote branches pull requests commits worktrees recover stale organized matthew berman"
               >
-                <td class="cell-number">012</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -1015,14 +906,9 @@
                     stale until the repository is current and organized.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Valuable work is recovered and remaining repository state is intentional.</strong>
-                  <span>Branches, pull requests, commits, and worktrees are current, owned, or safely removed with evidence.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1033,7 +919,6 @@
                 data-category="operations"
                 data-search="stale safe batch release pending changes pull requests exclude unfinished combine valid release together matthew berman"
               >
-                <td class="cell-number">013</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Operations</span>
@@ -1051,14 +936,9 @@
                     together.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Only current, complete changes ship in the combined release.</strong>
-                  <span>The released revision is the latest integrated main that contains every selected change.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1069,7 +949,6 @@
                 data-category="operations"
                 data-search="production data cleanup records allowed definition classification logic verify remaining matthew berman"
               >
-                <td class="cell-number">014</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Operations</span>
@@ -1087,14 +966,9 @@
                     logic, and verify the remaining data.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Every remaining record meets the allowed definition.</strong>
-                  <span>Representative classification tests and a post-cleanup audit prove the retained data is valid.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1105,7 +979,6 @@
                 data-category="operations"
                 data-search="post release baseline benchmarks standard results current releases finish record matthew berman"
               >
-                <td class="cell-number">015</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Operations</span>
@@ -1122,14 +995,9 @@
                     and record the results as the new baseline.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The new baseline belongs to the completed release.</strong>
-                  <span>Revision, environment, benchmark version, conditions, and results are recorded together.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1140,7 +1008,6 @@
                 data-category="engineering"
                 data-search="ticket bug report failing behavior customer complaint review ready patch reproduce root cause evidence hiten shah"
               >
-                <td class="cell-number">016</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -1164,14 +1031,9 @@
                     before-and-after proof, risks, and pull-request summary.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The failure is fixed, verified, and ready for review.</strong>
-                  <span>The issue reproduces before the fix, no longer reproduces afterward, and relevant regression checks pass.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1182,7 +1044,6 @@
                 data-category="operations"
                 data-search="customer ai deployment priority production workflow dry run approval rollout monitor roi agentled"
               >
-                <td class="cell-number">017</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Operations</span>
@@ -1206,14 +1067,9 @@
                     update, lessons saved, and next review.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>One customer priority reaches a proven terminal state.</strong>
-                  <span>The workflow reaches its agreed rollout stage, a production issue is fixed, or a blocker is escalated with an owner and next step.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1224,7 +1080,6 @@
                 data-category="content"
                 data-search="product update podcast nightly public features repository jellypod mcp episode pierson marks"
               >
-                <td class="cell-number">018</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Content</span>
@@ -1248,14 +1103,9 @@
                     episode, sources, and review result.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The episode accurately covers every meaningful public update.</strong>
-                  <span>Finish with a review-ready three-to-five-minute episode, or a confirmed no-episode result when nothing meaningful shipped.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1266,7 +1116,6 @@
                 data-category="engineering"
                 data-search="clodex claude codex adversarial review fix findings threshold max iter pull request lukas kucinski"
               >
-                <td class="cell-number">019</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -1290,14 +1139,9 @@
                     checks, verdict, and remaining findings.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The pull request reaches the configured review bar.</strong>
-                  <span>Codex approves it or only explicitly accepted findings remain; errors, stalls, and exhausted limits are reported as such.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1308,7 +1152,6 @@
                 data-category="engineering"
                 data-search="loop harness scheduled coding agent claude skill isolated git worktree second agent verify ship istasha"
               >
-                <td class="cell-number">020</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -1331,14 +1174,9 @@
                     staged output, verifier result, delivery status, and next run.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Only independently verified output ships.</strong>
-                  <span>A second-agent pass releases the configured output; a failed verification preserves evidence and produces no external change.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1349,7 +1187,6 @@
                 data-category="design"
                 data-search="boeing 747 benchmark three js threejs vision self verifiable camera angles 100 percent satisfied victormustar"
               >
-                <td class="cell-number">021</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Design</span>
@@ -1373,14 +1210,9 @@
                     renders, scores, remaining gaps, and run summary.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The Boeing 747 meets the visual bar from all nine angles.</strong>
-                  <span>The same camera rig and rubric show every required view meeting the preset threshold, or the run reports stagnation, budget exhaustion, and remaining gaps.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1391,7 +1223,6 @@
                 data-category="design"
                 data-search="war loops autonomous frontend designer URL image genuine browser ground truth design spec pencil forge static motion responsive swayam"
               >
-                <td class="cell-number">022</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Design</span>
@@ -1414,14 +1245,9 @@
                     builds, spec, renders, scores, and remaining gaps.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The builds match the source across all three fidelity axes.</strong>
-                  <span>Static appearance, experiential motion, and responsive reflow pass their gates, or the run reports stagnation or a blocked capture.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1432,7 +1258,6 @@
                 data-category="evaluation"
                 data-search="self improving champion challenger genome gate working signal guard goodhart bounded optimization jose munoz"
               >
-                <td class="cell-number">023</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Evaluation</span>
@@ -1457,14 +1282,9 @@
                     remaining failures.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The best holdout-tested champion is returned.</strong>
-                  <span>Every challenger is logged, and accepted changes beat the previous champion on untouched cases without weakening a must-pass check.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1475,7 +1295,6 @@
                 data-category="evaluation"
                 data-search="devils advocate critic builder design red team objection log architecture adversarial review anonymous contributor"
               >
-                <td class="cell-number">024</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Evaluation</span>
@@ -1500,14 +1319,9 @@
                     stalemate.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>No high-impact objection remains open.</strong>
-                  <span>Every logged objection is verified as resolved or explicitly accepted with evidence, or the final report truthfully records a two-round stalemate.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1516,11 +1330,12 @@
                 class="loop-row"
                 data-copy-root
                 data-category="engineering"
+                data-featured="true"
                 data-search="fresh clone clean environment readme onboarding setup documentation hidden assumptions disposable 0xumbra"
               >
-                <td class="cell-number">025</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
+                    <span class="loop-featured">Featured</span>
                     <span class="loop-category">Engineering</span>
                     <span class="loop-attribution">By 0xUmbra</span>
                   </div>
@@ -1542,14 +1357,9 @@
                     Return exact commands, gaps closed, and remaining blockers.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>A clean environment reaches the documented ready state using only the README.</strong>
-                  <span>The final run uses only the onboarding guide and needs no unstated dependency, configuration, or manual repair.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1560,7 +1370,6 @@
                 data-category="design"
                 data-search="infinite clickbait youtube thumbnail concepts inspiration channel score iterate top three alex ff visual design"
               >
-                <td class="cell-number">026</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Design</span>
@@ -1584,14 +1393,9 @@
                     previews, final scores, and rationale.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>One accurate thumbnail clears the fixed quality threshold.</strong>
-                  <span>The winner outscores the alternatives under the same conditions, remains legible at realistic sizes, and represents the video accurately.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1602,7 +1406,6 @@
                 data-category="engineering"
                 data-search="autonomy loop builder adversarial reviewer mutation testing proof test worktree frozen invariant inferencegod claude code"
               >
-                <td class="cell-number">027</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -1626,14 +1429,9 @@
                     the commit, gate evidence, test proof, trust tier, and risks.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Every accepted wave passes autonomy-loop's proof-of-test gate.</strong>
-                  <span>The new test fails without the change, passes with it, every configured gate passes, and protected production changes remain human-gated.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1644,7 +1442,6 @@
                 data-category="engineering"
                 data-search="codex completion contract goal proof evidence audit definition done false completion 3goblack dis trackted"
               >
-                <td class="cell-number">028</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -1668,14 +1465,9 @@
                     table, status, owner, and next action.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Every Codex Goal requirement has current, adequate proof.</strong>
-                  <span>The final audit contains no weak, missing, or contradicted required item; otherwise the work remains open, blocked, or exhausted.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1686,7 +1478,6 @@
                 data-category="evaluation"
                 data-search="revolve self improvement checkpoint incumbent candidate revision experiment evaluation promotion rollback agent zero"
               >
-                <td class="cell-number">029</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Evaluation</span>
@@ -1710,14 +1501,9 @@
                     rollback, and next action.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The best Revolve checkpoint wins within one evaluation revision.</strong>
-                  <span>The incumbent and candidates have comparable recorded runs, accepted changes pass every guard, rollback is available, and live promotion has approval.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1726,11 +1512,12 @@
                 class="loop-row"
                 data-copy-root
                 data-category="engineering"
+                data-featured="true"
                 data-search="five minute repository maintainer codex orchestration triage threads autoreview live proof peter steinberger"
               >
-                <td class="cell-number">030</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
+                    <span class="loop-featured">Featured</span>
                     <span class="loop-category">Engineering</span>
                     <span class="loop-attribution">By Peter Steinberger</span>
                   </div>
@@ -1753,14 +1540,9 @@
                     no work.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>Every repository item reaches a proven handoff or terminal state.</strong>
-                  <span>Authorized autonomous work lands with evidence; other items are decision-ready, blocked with one exact ask, or recorded as a clean no-op.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1771,7 +1553,6 @@
                 data-category="engineering"
                 data-search="recent user feedback threads corrections reported issues project audit failure patterns regression prevention matthew berman coding agent"
               >
-                <td class="cell-number">031</td>
                 <td class="cell-loop">
                   <div class="loop-meta">
                     <span class="loop-category">Engineering</span>
@@ -1795,14 +1576,9 @@
                     the issues, fixes, evidence, and blockers.
                   </p>
                 </td>
-                <td class="cell-check">
-                  <span class="cell-label">Verify / stop</span>
-                  <strong>The issue inventory is closed and a fresh pattern audit is clean.</strong>
-                  <span>Every reported issue and newly found match has current proof of resolution; blocked, approval-gated, or budget-exhausted items remain explicitly open.</span>
-                </td>
                 <td class="cell-action">
                   <button class="copy-button" type="button">
-                    <span>Copy</span>
+                    <span>Copy loop</span>
                   </button>
                 </td>
               </tr>
@@ -1845,6 +1621,46 @@
             Next
           </button>
         </nav>
+
+        <section
+          class="skill-promo"
+          id="agent-skill"
+          aria-labelledby="agent-skill-title"
+        >
+          <div class="skill-promo-copy">
+            <p class="skill-promo-kicker">Agent skill</p>
+            <h2 id="agent-skill-title">
+              Use Loop Library in your coding agent.
+            </h2>
+            <p>
+              Find a published loop or design one directly from your agent.
+            </p>
+          </div>
+
+          <div class="skill-promo-actions">
+            <code class="skill-install-command" data-skill-install-command
+              >npx skills add Forward-Future/loop-library --skill loop-library
+              -g</code
+            >
+            <div class="skill-action-row">
+              <button
+                class="skill-copy-button"
+                type="button"
+                data-copy-skill-command
+              >
+                <span>Copy command</span>
+              </button>
+              <a
+                class="skill-github-link"
+                href="https://github.com/Forward-Future/loop-library"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View repository
+              </a>
+            </div>
+          </div>
+        </section>
 
       </section>
 

--- a/site/script.js
+++ b/site/script.js
@@ -68,6 +68,75 @@ const paginationStatus = document.querySelector("#pagination-status");
 const toast = document.querySelector("#toast");
 const PAGE_SIZE = 25;
 
+const loopTableBody = document.querySelector(".loop-table tbody");
+loopRows.sort(
+  (a, b) =>
+    Number(b.dataset.featured === "true") -
+    Number(a.dataset.featured === "true"),
+);
+
+if (loopTableBody) {
+  loopRows.forEach((row) => loopTableBody.append(row));
+}
+
+const promptPreviews = loopRows
+  .map((row, index) => {
+    const prompt = row.querySelector("[data-prompt]");
+
+    if (!prompt) {
+      return null;
+    }
+
+    const loopSlug =
+      row
+        .querySelector(".loop-title-link")
+        ?.getAttribute("href")
+        ?.split("/")
+        .filter(Boolean)
+        .at(-1) || `item-${index + 1}`;
+    const button = document.createElement("button");
+    const preview = { button, prompt, row };
+
+    prompt.id = `loop-prompt-${loopSlug}`;
+    prompt.classList.add("is-collapsible");
+    button.className = "loop-prompt-toggle";
+    button.type = "button";
+    button.hidden = true;
+    button.textContent = "Show more";
+    button.setAttribute("aria-controls", prompt.id);
+    button.setAttribute("aria-expanded", "false");
+    prompt.insertAdjacentElement("afterend", button);
+
+    button.addEventListener("click", () => {
+      const isExpanded = button.getAttribute("aria-expanded") === "true";
+      const nextExpanded = !isExpanded;
+
+      button.setAttribute("aria-expanded", String(nextExpanded));
+      button.textContent = nextExpanded ? "Show less" : "Show more";
+      prompt.classList.toggle("is-expanded", nextExpanded);
+    });
+
+    return preview;
+  })
+  .filter(Boolean);
+
+function syncPromptToggle({ button, prompt, row }) {
+  if (row.hidden) {
+    return;
+  }
+
+  if (button.getAttribute("aria-expanded") === "true") {
+    button.hidden = false;
+    return;
+  }
+
+  button.hidden = prompt.scrollHeight <= prompt.clientHeight + 1;
+}
+
+function syncVisiblePromptToggles() {
+  promptPreviews.forEach(syncPromptToggle);
+}
+
 let activeCategory = "all";
 let currentPage = 1;
 let toastTimer;
@@ -124,6 +193,8 @@ function updateLibrary() {
     paginationNext.disabled = currentPage === totalPages;
     paginationStatus.textContent = `Page ${currentPage} of ${totalPages}`;
   }
+
+  window.requestAnimationFrame(syncVisiblePromptToggles);
 }
 
 function focusFirstVisibleLoop() {
@@ -188,6 +259,12 @@ if (paginationNext) {
 
 updateLibrary();
 
+let promptResizeFrame;
+window.addEventListener("resize", () => {
+  window.cancelAnimationFrame(promptResizeFrame);
+  promptResizeFrame = window.requestAnimationFrame(syncVisiblePromptToggles);
+});
+
 function showToast(message) {
   if (!toast) {
     return;
@@ -227,12 +304,15 @@ async function copyText(text) {
 }
 
 document.querySelectorAll(".copy-button").forEach((button) => {
+  const label = button.querySelector("span");
+  const defaultLabel = label?.textContent;
+  let copyLabelResetTimer;
+
   button.addEventListener("click", async () => {
     const copyRoot = button.closest("[data-copy-root]");
     const prompt = copyRoot?.querySelector("[data-prompt]")?.textContent.trim();
-    const label = button.querySelector("span");
 
-    if (!prompt || !label) {
+    if (!prompt || !label || !defaultLabel) {
       return;
     }
 
@@ -240,8 +320,9 @@ document.querySelectorAll(".copy-button").forEach((button) => {
       await copyText(prompt.replace(/\s+/g, " "));
       label.textContent = "Copied";
       showToast("Loop copied to clipboard.");
-      window.setTimeout(() => {
-        label.textContent = "Copy";
+      window.clearTimeout(copyLabelResetTimer);
+      copyLabelResetTimer = window.setTimeout(() => {
+        label.textContent = defaultLabel;
       }, 1800);
     } catch {
       showToast("Copy failed. Select the prompt text instead.");

--- a/site/styles.css
+++ b/site/styles.css
@@ -361,6 +361,10 @@ code {
   content: "";
 }
 
+.library-hero {
+  max-width: 760px;
+}
+
 .library-intro h1 {
   max-width: 1100px;
   margin-bottom: 16px;
@@ -384,7 +388,7 @@ code {
 }
 
 .library-intro {
-  max-width: 920px;
+  max-width: 760px;
 }
 
 .skill-promo {
@@ -477,8 +481,8 @@ code {
   text-decoration-thickness: 4px;
 }
 
-.skill-promo + .library-controls {
-  margin-top: 18px;
+.pagination + .skill-promo {
+  margin-top: clamp(40px, 5vw, 64px);
 }
 
 .section-heading {
@@ -626,7 +630,7 @@ code {
 }
 
 .loop-table th {
-  padding: 11px 12px;
+  padding: 11px 18px;
   border-bottom: 1px solid var(--ink);
   font-family: var(--font-mono);
   font-size: 0.62rem;
@@ -636,20 +640,12 @@ code {
   text-transform: uppercase;
 }
 
-.loop-table th:nth-child(1) {
-  width: 60px;
-}
-
 .loop-table th:nth-child(2) {
-  width: 56%;
-}
-
-.loop-table th:nth-child(4) {
-  width: 72px;
+  width: 124px;
 }
 
 .loop-table td {
-  padding: 22px 12px;
+  padding: 18px;
   border-bottom: 1px solid var(--line);
   vertical-align: top;
 }
@@ -658,15 +654,8 @@ code {
   display: none;
 }
 
-.cell-number {
-  color: var(--orange);
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  font-weight: 700;
-}
-
 .cell-loop h3 {
-  margin-bottom: 8px;
+  margin-bottom: 6px;
   font-size: 1.08rem;
   letter-spacing: -0.025em;
 }
@@ -701,6 +690,22 @@ code {
   content: "·";
 }
 
+.loop-featured {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  min-height: 18px;
+  padding: 2px 5px;
+  color: var(--charcoal);
+  background: var(--orange);
+  font-family: var(--font-mono);
+  font-size: 0.54rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
 .loop-title-link {
   scroll-margin-top: 80px;
   text-decoration-color: var(--orange);
@@ -713,8 +718,7 @@ code {
   text-decoration-thickness: 4px;
 }
 
-.cell-loop p,
-.cell-check {
+.cell-loop p {
   color: var(--muted);
   font-size: 0.9rem;
 }
@@ -725,30 +729,47 @@ code {
 }
 
 .cell-loop .loop-summary {
-  margin-bottom: 10px;
-  color: var(--ink);
-  font-size: 0.92rem;
-  font-weight: 600;
-  line-height: 1.45;
+  display: none;
 }
 
 .cell-loop [data-prompt] {
+  margin-top: 8px;
+  color: var(--muted);
   font-size: 0.86rem;
+  line-height: 1.5;
 }
 
-.cell-check strong,
-.cell-check > span:not(.cell-label) {
-  display: block;
+.cell-loop [data-prompt].is-collapsible:not(.is-expanded) {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 }
 
-.cell-check strong {
-  margin-bottom: 6px;
+.loop-prompt-toggle {
+  padding: 0;
+  margin-top: 8px;
+  border: 0;
   color: var(--ink);
-  font-size: 0.88rem;
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-decoration: underline;
+  text-decoration-color: var(--orange);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
 }
 
-.cell-label {
-  display: none;
+.loop-prompt-toggle:hover,
+.loop-prompt-toggle:focus-visible {
+  text-decoration-thickness: 4px;
+}
+
+.cell-action {
+  text-align: right;
 }
 
 .copy-button {
@@ -1652,50 +1673,32 @@ code {
 
   .loop-row {
     display: grid;
-    grid-template-columns: 56px minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
-      "number . action"
-      "loop loop loop"
-      "check check check";
-    padding: 18px 0;
+      "loop"
+      "action";
+    padding: 14px 0;
     border-bottom: 1px solid var(--ink);
   }
 
   .loop-table td {
     display: block;
-    padding: 6px 12px;
+    padding: 6px 16px;
     border-bottom: 0;
-  }
-
-  .cell-number {
-    grid-area: number;
   }
 
   .cell-loop {
     grid-area: loop;
-    padding-top: 16px !important;
+    padding-top: 6px !important;
   }
 
-  .cell-check {
-    grid-area: check;
-    margin-top: 8px;
-    padding-top: 14px !important;
-    border-top: 1px solid var(--line) !important;
+  .cell-loop [data-prompt].is-collapsible:not(.is-expanded) {
+    -webkit-line-clamp: 4;
   }
 
   .cell-action {
     grid-area: action;
-  }
-
-  .cell-label {
-    display: block;
-    margin-bottom: 5px;
-    color: var(--muted);
-    font-family: var(--font-mono);
-    font-size: 0.58rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
+    text-align: left;
   }
 
   .detail-hero h1 {


### PR DESCRIPTION
## What changed

- feature and automatically sort three selected loops to the top of the existing catalog
- simplify the homepage hero and navigation
- remove row numbering and verification columns
- show clamped prompt previews with accessible Show more controls
- rename row actions to Copy loop and add modest row padding
- make repeated copy clicks restore the button label reliably

## Why

The catalog had too much above-the-fold noise and each row exposed more structure than readers needed. Featured loops now live directly in the catalog while the prompt itself is easier to scan and copy.

## Validation

- full generated catalog/detail-page/social-image build
- `node scripts/audit-seo-geo.mjs`
- `node scripts/check.mjs`
- `npm --prefix worker run check` (12 passing)
- here.now branding validator (66 credits across 33 pages)
- desktop and mobile local browser verification
- autoreview clean after fixing the repeated-copy label timer