### PR TITLE
[codex] Harden loop catalog validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           node --check scripts/build-social-images.mjs
           node --check scripts/audit-seo-geo.mjs
           node --check scripts/loop-data.mjs
+          node --check scripts/validate-loop-data.mjs
           node --check site/script.js
           node scripts/audit-seo-geo.mjs
           node scripts/check.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@
   node --check site/script.js
   node --check scripts/build-loop-pages.mjs
   node --check scripts/loop-data.mjs
+  node --check scripts/validate-loop-data.mjs
   node scripts/audit-seo-geo.mjs
   node scripts/check.mjs
   npm --prefix worker run check

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ node --check scripts/build-social-images.mjs
 node --check site/script.js
 node --check scripts/build-loop-pages.mjs
 node --check scripts/loop-data.mjs
+node --check scripts/validate-loop-data.mjs
 node scripts/audit-seo-geo.mjs
 node scripts/check.mjs
 npm --prefix worker run check

--- a/scripts/build-loop-pages.mjs
+++ b/scripts/build-loop-pages.mjs
@@ -7,6 +7,7 @@ import { loops, site } from "./loop-data.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const outputRoot = path.join(root, "site");
+const loopBySlug = new Map(loops.map((loop) => [loop.slug, loop]));
 
 function escapeHtml(value) {
   return String(value)
@@ -61,8 +62,7 @@ function shareActions(loop, url) {
 
 function relatedLinks(loop) {
   return loop.related
-    .map((slug) => loops.find((candidate) => candidate.slug === slug))
-    .filter(Boolean)
+    .map((slug) => loopBySlug.get(slug))
     .map(
       (related) => `
                 <a class="related-loop-link" href="../${escapeHtml(related.slug)}/">

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -17,6 +17,7 @@ import {
   renderCatalogMarkdown,
 } from "./build-skill-catalog.mjs";
 import { escapeJsonForHtmlScript } from "./html-script-utils.mjs";
+import { validateLoopData } from "./validate-loop-data.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const siteRoot = path.join(root, "site");
@@ -128,6 +129,15 @@ function pngSize(buffer) {
 
 function wordCount(value) {
   return value.trim().split(/\s+/).length;
+}
+
+function formatDate(value) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T00:00:00Z`));
 }
 
 assert(structuredDataMatch);
@@ -263,6 +273,12 @@ assert.deepEqual(
 assert(loops.every((loop) => !Object.hasOwn(loop, "type")));
 assert(loops.every((loop) => !Object.hasOwn(loop, "typeSlug")));
 assert(requestedConceptSlugs.every((slug) => slugs.has(slug)));
+const invalidRelatedLoops = structuredClone(loops);
+invalidRelatedLoops.at(-1).related = ["missing-review-fixture"];
+assert.throws(
+  () => validateLoopData(invalidRelatedLoops),
+  /axelrod-subagent-arena-loop references unknown related loop: missing-review-fixture/,
+);
 for (const [slug, anchors] of submissionPromptAnchors) {
   const prompt = loopBySlug.get(slug)?.prompt ?? "";
   const normalizedPrompt = prompt.toLowerCase();
@@ -282,6 +298,7 @@ assert.equal(publicCatalogJsonSource, renderCatalogJson());
 assert.equal(publicCatalog.schemaVersion, catalogSchemaVersion);
 assert.equal(publicCatalog.name, siteMeta.name);
 assert.equal(publicCatalog.publisher, siteMeta.publisher);
+assert.equal(publicCatalog.description, siteMeta.description);
 assert.equal(publicCatalog.url, siteMeta.baseUrl);
 assert.equal(publicCatalog.catalogUrl, `${siteMeta.baseUrl}catalog.json`);
 assert.equal(publicCatalog.markdownUrl, `${siteMeta.baseUrl}catalog.md`);
@@ -378,6 +395,16 @@ for (const [index, loop] of loops.entries()) {
     catalogLoop.related.map(({ slug }) => slug),
     loop.related,
   );
+  assert.deepEqual(
+    catalogLoop.related.map(({ title }) => title),
+    loop.related.map((relatedSlug) => loopBySlug.get(relatedSlug).title),
+  );
+  assert.deepEqual(
+    catalogLoop.related.map(({ url: relatedUrl }) => relatedUrl),
+    loop.related.map(
+      (relatedSlug) => `${siteMeta.baseUrl}loops/${relatedSlug}/`,
+    ),
+  );
   assert.equal(catalogLoop.sourceUrl, loop.sourceUrl);
   assert(loop.related.every((relatedSlug) => slugs.has(relatedSlug)));
   assert(html.includes(loop.title));
@@ -409,6 +436,14 @@ for (const [index, loop] of loops.entries()) {
   );
   assert(html.includes(homepageHref));
   assert(page.includes(`<title>${escapeHtml(loop.seoTitle)}</title>`));
+  assert(
+    page.includes(
+      `<meta name="description" content="${escapeHtml(loop.description)}"`,
+    ),
+  );
+  assert(
+    page.includes(`<meta name="author" content="${escapeHtml(loop.author)}"`),
+  );
   assert(page.includes(`<link rel="canonical" href="${url}"`));
   assert(
     page.includes(
@@ -428,6 +463,16 @@ for (const [index, loop] of loops.entries()) {
   assert(
     page.includes(
       `<meta property="og:image:alt" content="${escapeHtml(imageAlt)}"`,
+    ),
+  );
+  assert(
+    page.includes(
+      `<meta property="article:published_time" content="${loop.published}"`,
+    ),
+  );
+  assert(
+    page.includes(
+      `<meta property="article:modified_time" content="${loop.modified}"`,
     ),
   );
   assert(page.includes('<meta name="twitter:card" content="summary_large_image"'));
@@ -459,6 +504,16 @@ for (const [index, loop] of loops.entries()) {
   assert(!page.includes(`<p class="eyebrow">${loop.categoryLabel}</p>`));
   assert(page.includes("<dt>Published</dt>"));
   assert(page.includes("<dt>Updated</dt>"));
+  assert(
+    page.includes(
+      `<time datetime="${loop.published}">${escapeHtml(formatDate(loop.published))}</time>`,
+    ),
+  );
+  assert(
+    page.includes(
+      `<time datetime="${loop.modified}">${escapeHtml(formatDate(loop.modified))}</time>`,
+    ),
+  );
   assert(page.includes("Use this when"));
   assert(page.includes("How to run it"));
   assert(page.includes("Why it works"));
@@ -490,13 +545,51 @@ for (const [index, loop] of loops.entries()) {
   const article = pageStructuredData["@graph"].find(
     (item) => item["@type"] === "Article",
   );
+  assert(article);
+
+  const author = article.author;
+  const relatedLinkMatches = [
+    ...page.matchAll(
+      /<a class="related-loop-link" href="\.\.\/([^/]+)\/">\s*([^<]+?)\s*<\/a>/g,
+    ),
+  ];
 
   assert.equal(article.url, url);
   assert.equal(article.headline, loop.title);
+  assert.equal(article.description, loop.description);
+  assert.equal(article.mainEntityOfPage, url);
+  assert.equal(article.datePublished, loop.published);
   assert.equal(article.dateModified, loop.modified);
+  assert.equal(article.articleSection, loop.categoryLabel);
+  assert.deepEqual(article.keywords, loop.keywords);
   assert.equal(article.image.url, imageUrl);
   assert.equal(article.image.width, 1200);
   assert.equal(article.image.height, 630);
+  assert.equal(author["@type"], "Person");
+  assert.equal(author.name, loop.author.split(" / ")[0]);
+  if (loop.author.includes(" / ")) {
+    assert.deepEqual(author.affiliation, {
+      "@id": `${siteMeta.baseUrl}#organization`,
+    });
+  } else {
+    assert.equal(author.affiliation, undefined);
+  }
+  assert.deepEqual(article.publisher, {
+    "@id": `${siteMeta.baseUrl}#organization`,
+  });
+  assert.deepEqual(article.isPartOf, {
+    "@id": `${siteMeta.baseUrl}#collection`,
+  });
+  assert.deepEqual(
+    relatedLinkMatches.map((match) => match[1]),
+    loop.related,
+  );
+  assert.deepEqual(
+    relatedLinkMatches.map((match) => match[2].trim()),
+    loop.related.map((relatedSlug) =>
+      escapeHtml(loopBySlug.get(relatedSlug).title),
+    ),
+  );
   if (loop.sourceUrl) {
     assert.equal(article.isBasedOn, loop.sourceUrl);
     assert(

--- a/scripts/loop-data.mjs
+++ b/scripts/loop-data.mjs
@@ -1,3 +1,5 @@
+import { validateLoopData } from "./validate-loop-data.mjs";
+
 export const site = {
   name: "Loop Library",
   publisher: "Forward Future",
@@ -1708,3 +1710,5 @@ export const loops = [
     related: ["boeing-747-benchmark", "full-product-evaluation-loop"],
   },
 ];
+
+validateLoopData(loops);

--- a/scripts/validate-loop-data.mjs
+++ b/scripts/validate-loop-data.mjs
@@ -1,0 +1,177 @@
+function fail(message) {
+  throw new Error(message);
+}
+
+function requireCondition(condition, message) {
+  if (!condition) {
+    fail(message);
+  }
+}
+
+function requireText(value, label) {
+  requireCondition(typeof value === "string", `${label} must be a string.`);
+  requireCondition(value.trim().length > 0, `${label} must not be empty.`);
+}
+
+function requireIsoDate(value, label) {
+  requireText(value, label);
+  requireCondition(
+    /^\d{4}-\d{2}-\d{2}$/.test(value),
+    `${label} must use YYYY-MM-DD.`,
+  );
+
+  const parsed = new Date(`${value}T00:00:00Z`);
+  requireCondition(
+    !Number.isNaN(parsed.getTime()) &&
+      parsed.toISOString().slice(0, 10) === value,
+    `${label} must be a valid calendar date.`,
+  );
+}
+
+function requireUniqueText(loops, field) {
+  const ownerByValue = new Map();
+
+  for (const loop of loops) {
+    const normalized = loop[field].trim().toLowerCase();
+    const owner = ownerByValue.get(normalized);
+
+    requireCondition(
+      owner === undefined,
+      `${loop.slug}.${field} duplicates ${owner}.${field}.`,
+    );
+    ownerByValue.set(normalized, loop.slug);
+  }
+}
+
+export function validateLoopData(loops) {
+  requireCondition(Array.isArray(loops), "Loop catalog must be an array.");
+  requireCondition(loops.length > 0, "Loop catalog must not be empty.");
+
+  const requiredTextFields = [
+    "slug",
+    "title",
+    "summary",
+    "seoTitle",
+    "description",
+    "categoryLabel",
+    "author",
+    "prompt",
+    "verifyTitle",
+    "verifyDetail",
+    "useWhen",
+    "why",
+    "note",
+  ];
+
+  loops.forEach((loop, index) => {
+    requireCondition(
+      loop !== null && typeof loop === "object" && !Array.isArray(loop),
+      `Loop ${index + 1} must be an object.`,
+    );
+
+    const label =
+      typeof loop.slug === "string" && loop.slug.trim()
+        ? loop.slug
+        : `loop ${index + 1}`;
+
+    requireText(loop.number, `${label}.number`);
+    for (const field of requiredTextFields) {
+      requireText(loop[field], `${label}.${field}`);
+    }
+
+    requireCondition(
+      loop.number === String(index + 1).padStart(3, "0"),
+      `${label}.number must match catalog order.`,
+    );
+    requireCondition(
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(loop.slug),
+      `${label}.slug must use lowercase kebab-case.`,
+    );
+
+    requireIsoDate(loop.published, `${label}.published`);
+    requireIsoDate(loop.modified, `${label}.modified`);
+    requireCondition(
+      loop.modified >= loop.published,
+      `${label}.modified must be on or after published.`,
+    );
+
+    requireCondition(
+      Array.isArray(loop.steps),
+      `${label}.steps must be an array.`,
+    );
+    requireCondition(
+      loop.steps.length >= 3,
+      `${label}.steps must include at least three steps.`,
+    );
+    loop.steps.forEach((step, stepIndex) =>
+      requireText(step, `${label}.steps[${stepIndex}]`),
+    );
+
+    requireCondition(
+      Array.isArray(loop.keywords),
+      `${label}.keywords must be an array.`,
+    );
+    requireCondition(
+      loop.keywords.length >= 3,
+      `${label}.keywords must include at least three terms.`,
+    );
+    loop.keywords.forEach((keyword, keywordIndex) =>
+      requireText(keyword, `${label}.keywords[${keywordIndex}]`),
+    );
+    requireCondition(
+      new Set(loop.keywords.map((keyword) => keyword.trim().toLowerCase()))
+        .size === loop.keywords.length,
+      `${label}.keywords must be unique.`,
+    );
+
+    requireCondition(
+      Array.isArray(loop.related),
+      `${label}.related must be an array.`,
+    );
+    requireCondition(
+      loop.related.length >= 1,
+      `${label}.related must include at least one loop.`,
+    );
+    loop.related.forEach((slug, relatedIndex) =>
+      requireText(slug, `${label}.related[${relatedIndex}]`),
+    );
+    requireCondition(
+      new Set(loop.related).size === loop.related.length,
+      `${label}.related must not contain duplicates.`,
+    );
+    requireCondition(
+      !loop.related.includes(loop.slug),
+      `${label}.related must not link to itself.`,
+    );
+
+    if (Object.hasOwn(loop, "sourceUrl")) {
+      requireText(loop.sourceUrl, `${label}.sourceUrl`);
+
+      let sourceUrl;
+      try {
+        sourceUrl = new URL(loop.sourceUrl);
+      } catch {
+        fail(`${label}.sourceUrl must be a valid HTTP URL.`);
+      }
+
+      requireCondition(
+        sourceUrl.protocol === "http:" || sourceUrl.protocol === "https:",
+        `${label}.sourceUrl must be a valid HTTP URL.`,
+      );
+    }
+  });
+
+  for (const field of ["slug", "title", "seoTitle", "description", "prompt"]) {
+    requireUniqueText(loops, field);
+  }
+
+  const slugs = new Set(loops.map((loop) => loop.slug));
+  for (const loop of loops) {
+    for (const relatedSlug of loop.related) {
+      requireCondition(
+        slugs.has(relatedSlug),
+        `${loop.slug} references unknown related loop: ${relatedSlug}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Validate canonical loop data as it loads, before any generator can modify output.
- Reject missing, duplicate, self-referential, malformed, or incomplete catalog data with actionable errors.
- Replace silent related-loop drops with validated map lookups.
- Strengthen generated catalog, metadata, structured-data, date, and related-link checks.
- Add the validator to CI and maintainer verification docs.

This carries forward the valuable intent of #30 and #31 from @williamclay8 while fixing the review findings in both patches. It supersedes those closed PRs.

## Failure-path proof

An injected unknown related-loop slug now exits before generation begins: all 42 existing loop pages remain present and `site/loops`, `site/sitemap.xml`, and `site/feed.xml` remain unchanged.

## Verification

- Full generated-artifact rebuild with no drift
- `node scripts/audit-seo-geo.mjs --json` — 0 critical/high/medium findings; 8 existing low length notes
- `node scripts/check.mjs`
- `npm --prefix worker run check` — 14/14 tests passing
- JSON validation and `git diff --check`
- Structured autoreview against current `origin/main` — clean, no actionable findings