### PR TITLE
[codex] Move agent skill promo near top

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -792,7 +792,7 @@ assert(!html.includes('data-type='));
 assert(!html.includes('class="cell-type"'));
 assert(!html.includes("type-badge"));
 assert(!html.includes('<th scope="col">Type</th>'));
-assert(html.includes("./styles.css?v=20260620-agent-guide"));
+assert(html.includes("./styles.css?v=20260620-skill-promo-top"));
 assert(html.includes("./script.js?v=20260620-agent-guide"));
 const homepagePostText =
   "Find Loops and create your own - Loop Library";
@@ -818,6 +818,9 @@ assert(!html.includes('class="answer-capsule"'));
 assert(!html.includes("Plain-language definition"));
 assert(!html.includes("What is an AI agent loop?"));
 assert(html.includes('id="agent-skill"'));
+assert(
+  html.indexOf('id="agent-skill"') < html.indexOf('class="library-controls"'),
+);
 assert(html.includes("Use Loop Library in your coding agent."));
 assert(html.includes('href="./agents/"'));
 assert(html.includes("Send an agent to the live guide"));

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="./styles.css?v=20260620-skill-promo-top" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -540,6 +540,50 @@
           </div>
 
         </div>
+
+        <section
+          class="skill-promo"
+          id="agent-skill"
+          aria-labelledby="agent-skill-title"
+        >
+          <div class="skill-promo-copy">
+            <p class="skill-promo-kicker">Agent skill</p>
+            <h2 id="agent-skill-title">
+              Use Loop Library in your coding agent.
+            </h2>
+            <p>
+              Send an agent to the live guide, or install the skill for guided
+              finding, auditing, adapting, and loop design.
+            </p>
+          </div>
+
+          <div class="skill-promo-actions">
+            <code class="skill-install-command" data-skill-install-command
+              >npx skills add Forward-Future/loop-library --skill loop-library
+              -g</code
+            >
+            <div class="skill-action-row">
+              <a class="skill-github-link" href="./agents/">
+                Agent guide
+              </a>
+              <button
+                class="skill-copy-button"
+                type="button"
+                data-copy-skill-command
+              >
+                <span>Copy command</span>
+              </button>
+              <a
+                class="skill-github-link"
+                href="https://github.com/Forward-Future/loop-library"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View repository
+              </a>
+            </div>
+          </div>
+        </section>
 
         <div class="library-controls">
           <label class="search-control">
@@ -2118,50 +2162,6 @@
             Next
           </button>
         </nav>
-
-        <section
-          class="skill-promo"
-          id="agent-skill"
-          aria-labelledby="agent-skill-title"
-        >
-          <div class="skill-promo-copy">
-            <p class="skill-promo-kicker">Agent skill</p>
-            <h2 id="agent-skill-title">
-              Use Loop Library in your coding agent.
-            </h2>
-            <p>
-              Send an agent to the live guide, or install the skill for guided
-              finding, auditing, adapting, and loop design.
-            </p>
-          </div>
-
-          <div class="skill-promo-actions">
-            <code class="skill-install-command" data-skill-install-command
-              >npx skills add Forward-Future/loop-library --skill loop-library
-              -g</code
-            >
-            <div class="skill-action-row">
-              <a class="skill-github-link" href="./agents/">
-                Agent guide
-              </a>
-              <button
-                class="skill-copy-button"
-                type="button"
-                data-copy-skill-command
-              >
-                <span>Copy command</span>
-              </button>
-              <a
-                class="skill-github-link"
-                href="https://github.com/Forward-Future/loop-library"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                View repository
-              </a>
-            </div>
-          </div>
-        </section>
 
       </section>
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -569,8 +569,8 @@ code {
   text-decoration-thickness: 4px;
 }
 
-.pagination + .skill-promo {
-  margin-top: clamp(40px, 5vw, 64px);
+.skill-promo + .library-controls {
+  margin-top: 18px;
 }
 
 .section-heading {


### PR DESCRIPTION
## What changed

- moved the Agent skill promotion from below the full loop catalog to directly below the homepage hero
- restored compact spacing between the promotion and search controls
- added a regression assertion for the intended ordering and bumped the homepage stylesheet cache key

## Why

The promotion had been pushed below all 42 loops and pagination during a homepage simplification, making it effectively a footer element. This restores it near the top where visitors can discover it before browsing the catalog.

## Validation

- `node scripts/audit-seo-geo.mjs`
- `node scripts/check.mjs`
- `npm --prefix worker run check`
- JavaScript syntax, JSON, and `git diff --check` validations
- structured Codex autoreview: clean, no actionable findings
