### PR TITLE
[codex] Keep primary navigation visible everywhere

### DIFF
--- a/scripts/build-loop-pages.mjs
+++ b/scripts/build-loop-pages.mjs
@@ -248,11 +248,11 @@ function renderLoopPage(loop) {
     <link rel="alternate" type="text/plain" title="${escapeHtml(site.name)} plain-text catalog" href="${escapeHtml(site.baseUrl)}catalog.txt" />
     <link rel="help" href="${escapeHtml(site.baseUrl)}agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 ${structuredData(loop)}
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>${escapeHtml(loop.seoTitle)}</title>
   </head>
   <body>
@@ -272,8 +272,9 @@ ${structuredData(loop)}
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -293,6 +294,11 @@ ${structuredData(loop)}
         </button>
         <a class="nav-cta" href="../../#submit">Submit a loop</a>
         ${hereNowCredit("../../assets/here-now-icon.svg", "header")}
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -535,8 +535,8 @@ for (const [index, loop] of loops.entries()) {
     ),
   );
   assert(page.includes(`rel="help" href="${siteMeta.baseUrl}agents/"`));
-  assert(page.includes("../../styles.css?v=20260620-agent-guide"));
-  assert(page.includes("../../script.js?v=20260620-agent-guide"));
+  assert(page.includes("../../styles.css?v=20260620-primary-nav"));
+  assert(page.includes("../../script.js?v=20260620-primary-nav"));
   assert(page.includes(`<meta property="og:image" content="${imageUrl}"`));
   assert(page.includes(`<meta property="og:image:secure_url" content="${imageUrl}"`));
   assert(page.includes(`<meta property="og:image:type" content="${siteMeta.socialImageMimeType}"`));
@@ -603,7 +603,14 @@ for (const [index, loop] of loops.entries()) {
   assert(!page.includes("<h2>Topics</h2>"));
   assert(page.includes("Related loops"));
   assert(!page.includes("<dt>Type</dt>"));
-  assert(page.includes('href="../../learn/">What is a loop?</a>'));
+  assert(
+    page.includes(
+      '<a href="../../#library" aria-current="page">Loops</a>',
+    ),
+  );
+  assert(page.includes('<a href="../../learn/">Learn</a>'));
+  assert(page.includes('<a href="../../agents/">For agents</a>'));
+  assert.equal((page.match(/class="mobile-site-nav"/g) || []).length, 1);
   assert(!page.includes('href="../../#tips"'));
   assert(page.includes('data-copy-root'));
   assert(page.includes('class="share-actions" aria-label="Share this loop"'));
@@ -792,8 +799,8 @@ assert(!html.includes('data-type='));
 assert(!html.includes('class="cell-type"'));
 assert(!html.includes("type-badge"));
 assert(!html.includes('<th scope="col">Type</th>'));
-assert(html.includes("./styles.css?v=20260620-skill-promo-top"));
-assert(html.includes("./script.js?v=20260620-agent-guide"));
+assert(html.includes("./styles.css?v=20260620-primary-nav"));
+assert(html.includes("./script.js?v=20260620-primary-nav"));
 const homepagePostText =
   "Find Loops and create your own - Loop Library";
 assert(html.includes('class="share-actions" aria-label="Share Loop Library"'));
@@ -804,7 +811,10 @@ assert(html.includes('aria-label="Copy a Loop Library social post"'));
 assert(!html.includes("twitter.com/intent/tweet"));
 assert(!html.includes("Share on X"));
 assert(!html.includes(`<span>Copy link</span>`));
-assert(html.includes('href="./learn/"'));
+assert(html.includes('<a href="#library" aria-current="page">Loops</a>'));
+assert(html.includes('<a href="./learn/">Learn</a>'));
+assert(html.includes('<a href="./agents/">For agents</a>'));
+assert.equal((html.match(/class="mobile-site-nav"/g) || []).length, 1);
 assert(!html.includes('class="loop-guide"'));
 assert(!html.includes("A useful loop specifies:"));
 assert(!html.includes("Learn how loops work and run one"));
@@ -851,8 +861,8 @@ assert.equal(
   (learnHtml.match(/href="https:\/\/here\.now\/r\/signals"/g) || []).length,
   2,
 );
-assert(learnHtml.includes("../styles.css?v=20260620-agent-guide"));
-assert(learnHtml.includes("../script.js?v=20260620-agent-guide"));
+assert(learnHtml.includes("../styles.css?v=20260620-primary-nav"));
+assert(learnHtml.includes("../script.js?v=20260620-primary-nav"));
 assert(learnHtml.includes("How agent loops work"));
 assert(learnHtml.includes('<meta name="robots" content="index, follow"'));
 assert(learnHtml.includes("What makes a loop useful"));
@@ -873,6 +883,9 @@ assert(learnHtml.includes('id="claude-code"'));
 assert(learnHtml.includes('id="factory"'));
 assert(learnHtml.includes('id="devin"'));
 assert(learnHtml.includes('href="../agents/">For agents</a>'));
+assert(learnHtml.includes('<a href="../#library">Loops</a>'));
+assert(learnHtml.includes('<a href="./" aria-current="page">Learn</a>'));
+assert.equal((learnHtml.match(/class="mobile-site-nav"/g) || []).length, 1);
 assert(learnHtml.includes(`href="${siteMeta.baseUrl}llms.txt"`));
 assert(learnHtml.includes(`href="${siteMeta.baseUrl}agents/"`));
 assert.equal((agentHtml.match(/data-here-now-credit/g) || []).length, 2);
@@ -881,6 +894,10 @@ assert.equal(
   2,
 );
 assert(agentHtml.includes("Use Loop Library directly."));
+assert(agentHtml.includes('<a href="../#library">Loops</a>'));
+assert(agentHtml.includes('<a href="../learn/">Learn</a>'));
+assert(agentHtml.includes('<a href="./" aria-current="page">For agents</a>'));
+assert.equal((agentHtml.match(/class="mobile-site-nav"/g) || []).length, 1);
 assert(agentHtml.includes("No skill installation is required."));
 assert(agentHtml.includes('href="../catalog.json"'));
 assert(agentHtml.includes('href="../catalog.txt"'));
@@ -893,8 +910,8 @@ assert(agentHtml.includes("npx skills add Forward-Future/loop-library --skill lo
 assert(agentHtml.includes('<meta name="robots" content="index, follow"'));
 assert(agentHtml.includes(`href="${siteMeta.baseUrl}catalog.json"`));
 assert(agentHtml.includes(`href="${siteMeta.baseUrl}llms.txt"`));
-assert(agentHtml.includes("../styles.css?v=20260620-agent-guide"));
-assert(agentHtml.includes("../script.js?v=20260620-agent-guide"));
+assert(agentHtml.includes("../styles.css?v=20260620-primary-nav"));
+assert(agentHtml.includes("../script.js?v=20260620-primary-nav"));
 assert(html.includes("Repeatable AI Agent Workflows"));
 assert(html.includes('rel="sitemap"'));
 assert(html.includes(`href="${siteMeta.baseUrl}catalog.json"`));
@@ -984,6 +1001,8 @@ assert(
 );
 assert(!css.includes("outline: 2px solid var(--orange)"));
 assert(css.includes(".here-now-credit"));
+assert(css.includes(".mobile-site-nav"));
+assert(css.includes('.mobile-site-nav a[aria-current="page"]'));
 assert(css.includes(".agent-steps"));
 assert(css.includes(".agent-resource-grid"));
 assert(css.includes(".agent-install-block"));

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -76,8 +76,8 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260620-agent-guide" />
-    <script src="../script.js?v=20260620-agent-guide" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260620-primary-nav" />
+    <script src="../script.js?v=20260620-primary-nav" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -151,6 +151,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../#library">Loops</a>
+        <a href="../learn/">Learn</a>
+        <a href="./" aria-current="page">For agents</a>
       </nav>
     </header>
 

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260620-skill-promo-top" />
+    <link rel="stylesheet" href="./styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -451,7 +451,7 @@
         ]
       }
     </script>
-    <script src="./script.js?v=20260620-agent-guide" defer></script>
+    <script src="./script.js?v=20260620-primary-nav" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>
@@ -471,7 +471,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
+        <a href="#library" aria-current="page">Loops</a>
         <a href="./learn/">Learn</a>
+        <a href="./agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -509,6 +511,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="#library" aria-current="page">Loops</a>
+        <a href="./learn/">Learn</a>
+        <a href="./agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -74,8 +74,8 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260620-agent-guide" />
-    <script src="../script.js?v=20260620-agent-guide" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260620-primary-nav" />
+    <script src="../script.js?v=20260620-primary-nav" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -149,6 +149,11 @@
           </span>
         </a>
         <a class="nav-cta" href="../#submit">Submit a loop</a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../#library">Loops</a>
+        <a href="./" aria-current="page">Learn</a>
+        <a href="../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/100-percent-test-coverage-loop/index.html
+++ b/site/loops/100-percent-test-coverage-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>100% Test Coverage Loop for Coding Agents | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/accessibility-repair-loop/index.html
+++ b/site/loops/accessibility-repair-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Accessibility Repair Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/architecture-satisfaction-loop/index.html
+++ b/site/loops/architecture-satisfaction-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Architecture Refactoring Loop for Coding Agents | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/autonomy-loop/index.html
+++ b/site/loops/autonomy-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>autonomy-loop Builder-Reviewer Workflow | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/axelrod-subagent-arena-loop/index.html
+++ b/site/loops/axelrod-subagent-arena-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Axelrod Subagent Arena Benchmark | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/boeing-747-benchmark/index.html
+++ b/site/loops/boeing-747-benchmark/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Boeing 747 Three.js Vision Benchmark | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/clodex-adversarial-review-loop/index.html
+++ b/site/loops/clodex-adversarial-review-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Clodex Adversarial Code Review Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/codex-completion-contract-loop/index.html
+++ b/site/loops/codex-completion-contract-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Codex Completion Contract and Evidence Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/cold-load-trimmer-loop/index.html
+++ b/site/loops/cold-load-trimmer-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Cold-Load Byte Reduction Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/customer-ai-deployment-loop/index.html
+++ b/site/loops/customer-ai-deployment-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Customer AI Deployment Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/devils-advocate-design-loop/index.html
+++ b/site/loops/devils-advocate-design-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Devil&#39;s-Advocate Design Review Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/easy-onboarding-loop/index.html
+++ b/site/loops/easy-onboarding-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Fresh-State Onboarding Improvement Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/exhaustive-logging-coverage-loop/index.html
+++ b/site/loops/exhaustive-logging-coverage-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Logging Coverage Loop for Coding Agents | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/five-minute-repository-maintainer-loop/index.html
+++ b/site/loops/five-minute-repository-maintainer-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Five-Minute Repository Maintainer Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/fresh-clone-loop/index.html
+++ b/site/loops/fresh-clone-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Fresh Clone README Verification Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/full-product-evaluation-loop/index.html
+++ b/site/loops/full-product-evaluation-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Full Product Evaluation Loop for AI Systems | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/goal-forge-loop/index.html
+++ b/site/loops/goal-forge-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Goal Forge Specification Loop for Codex | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/housekeeper-loop/index.html
+++ b/site/loops/housekeeper-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Repository Housekeeper Cleanup Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/infinite-clickbait-loop/index.html
+++ b/site/loops/infinite-clickbait-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Infinite Clickbait Thumbnail Iteration Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/loop-harness-verification-loop/index.html
+++ b/site/loops/loop-harness-verification-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Loop Harness Second-Agent Verification Workflow | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/multi-llm-convergence-loop/index.html
+++ b/site/loops/multi-llm-convergence-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Multi-LLM Convergence Review Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/nightly-changelog-sweep/index.html
+++ b/site/loops/nightly-changelog-sweep/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Nightly Changelog Loop for Coding Agents | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/overnight-docs-sweep/index.html
+++ b/site/loops/overnight-docs-sweep/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Documentation Sweep for Coding Agents | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/pixel-safe-css-trim-loop/index.html
+++ b/site/loops/pixel-safe-css-trim-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Pixel-Safe CSS Reduction Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/post-release-baseline-loop/index.html
+++ b/site/loops/post-release-baseline-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Post-Release Benchmark Baseline Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/product-update-podcast-loop/index.html
+++ b/site/loops/product-update-podcast-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Product Update Podcast Automation Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/production-data-cleanup-loop/index.html
+++ b/site/loops/production-data-cleanup-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Production Data Cleanup Loop for AI Systems | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/production-error-sweep/index.html
+++ b/site/loops/production-error-sweep/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Production Error Triage Loop for Coding Agents | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/promise-to-proof-loop/index.html
+++ b/site/loops/promise-to-proof-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Promise-to-Proof Product Audit | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/propagation-compliance-loop/index.html
+++ b/site/loops/propagation-compliance-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Repository Propagation Compliance Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/quality-streak-loop/index.html
+++ b/site/loops/quality-streak-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Quality Streak Evaluation Loop for AI Products | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/recent-feedback-sweep/index.html
+++ b/site/loops/recent-feedback-sweep/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Recent-Feedback Project Audit | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/repository-cleanup-loop/index.html
+++ b/site/loops/repository-cleanup-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Repository Cleanup Loop for Coding Agents | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/revolve-self-improvement-loop/index.html
+++ b/site/loops/revolve-self-improvement-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Revolve Versioned Experiment Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/self-improving-champion-loop/index.html
+++ b/site/loops/self-improving-champion-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Self-Improving Champion Evaluation Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/seo-geo-visibility-loop/index.html
+++ b/site/loops/seo-geo-visibility-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>SEO and GEO Visibility Audit Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/stale-safe-batch-release-loop/index.html
+++ b/site/loops/stale-safe-batch-release-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Stale-Safe Batch Release Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/sub-50ms-page-load-loop/index.html
+++ b/site/loops/sub-50ms-page-load-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Sub-50 ms Page-Load Optimization Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/test-suite-speed-loop/index.html
+++ b/site/loops/test-suite-speed-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Test-Suite Speed Optimization Loop | Loop Library</title>
   </head>
   <body>
@@ -152,8 +152,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -191,6 +192,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/ticket-to-pr-ready-loop/index.html
+++ b/site/loops/ticket-to-pr-ready-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Ticket-to-PR-Ready Loop for Coding Agents | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/ui-ux-score-loop/index.html
+++ b/site/loops/ui-ux-score-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>Browser UI/UX Score Loop | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/loops/war-loops-frontend-designer/index.html
+++ b/site/loops/war-loops-frontend-designer/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-agent-guide" />
+    <link rel="stylesheet" href="../../styles.css?v=20260620-primary-nav" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -133,7 +133,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-agent-guide" defer></script>
+    <script src="../../script.js?v=20260620-primary-nav" defer></script>
     <title>War Loops Frontend Reconstruction Workflow | Loop Library</title>
   </head>
   <body>
@@ -153,8 +153,9 @@
       </a>
 
       <nav class="site-nav" aria-label="Primary navigation">
-        <a href="../../#library">All loops</a>
-        <a href="../../learn/">What is a loop?</a>
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -192,6 +193,11 @@
             <strong>here.now</strong>
           </span>
         </a>
+      </nav>
+      <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
+        <a href="../../#library" aria-current="page">Loops</a>
+        <a href="../../learn/">Learn</a>
+        <a href="../../agents/">For agents</a>
       </nav>
     </header>
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -203,6 +203,10 @@ code {
   text-underline-offset: 5px;
 }
 
+.mobile-site-nav {
+  display: none;
+}
+
 .theme-toggle {
   display: inline-flex;
   min-height: 34px;
@@ -1779,8 +1783,44 @@ code {
 }
 
 @media (max-width: 900px) {
+  html {
+    scroll-padding-top: 112px;
+  }
+
+  .site-header {
+    flex-wrap: wrap;
+    padding-top: 8px;
+    row-gap: 0;
+  }
+
   .site-nav > a:not(.nav-cta):not(.here-now-credit) {
     display: none;
+  }
+
+  .mobile-site-nav {
+    display: flex;
+    width: 100%;
+    flex: 0 0 100%;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(28px, 8vw, 64px);
+  }
+
+  .mobile-site-nav a {
+    padding: 11px 0 12px;
+    border-bottom: 3px solid transparent;
+    font-size: 0.86rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  .mobile-site-nav a:hover,
+  .mobile-site-nav a:focus-visible {
+    color: var(--orange);
+  }
+
+  .mobile-site-nav a[aria-current="page"] {
+    border-bottom-color: var(--orange);
   }
 
   .section-heading {
@@ -1967,7 +2007,7 @@ code {
   }
 }
 
-@media (max-width: 460px) {
+@media (max-width: 620px) {
   .brand-name {
     display: none;
   }
@@ -1979,6 +2019,14 @@ code {
 
   .site-nav {
     gap: 8px;
+  }
+
+  .mobile-site-nav {
+    gap: 24px;
+  }
+
+  .mobile-site-nav a {
+    font-size: 0.8rem;
   }
 
   .theme-toggle {


### PR DESCRIPTION
## Summary
- show Loops, Learn, and For agents on the homepage and every generated loop page
- add the same navigation as a responsive mobile row on all 45 HTML pages
- update the page generator and guardrail checks so the navigation cannot silently drift

## Verification
- `node scripts/build-skill-catalog.mjs`
- `node scripts/build-loop-pages.mjs`
- `node scripts/build-social-images.mjs`
- `node scripts/audit-seo-geo.mjs`
- `node scripts/check.mjs`
- `npm --prefix worker run check` (14/14)
- here.now branding validation (90 valid credits across 45 pages)
- visual checks at 390px, 480px, 621px, 900px, and 1440px
- AutoReview clean