### PR TITLE
[codex] Widen article guides and tighten Learn spacing

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -869,7 +869,7 @@ assert.equal(
   (learnHtml.match(/href="https:\/\/here\.now\/r\/signals"/g) || []).length,
   2,
 );
-assert(learnHtml.includes("../styles.css?v=20260620-primary-nav"));
+assert(learnHtml.includes("../styles.css?v=20260620-article-layout"));
 assert(learnHtml.includes("../script.js?v=20260620-primary-nav"));
 assert(learnHtml.includes("How agent loops work"));
 assert(learnHtml.includes('<meta name="robots" content="index, follow"'));
@@ -918,7 +918,7 @@ assert(agentHtml.includes("npx skills add Forward-Future/loop-library --skill lo
 assert(agentHtml.includes('<meta name="robots" content="index, follow"'));
 assert(agentHtml.includes(`href="${siteMeta.baseUrl}catalog.json"`));
 assert(agentHtml.includes(`href="${siteMeta.baseUrl}llms.txt"`));
-assert(agentHtml.includes("../styles.css?v=20260620-primary-nav"));
+assert(agentHtml.includes("../styles.css?v=20260620-article-layout"));
 assert(agentHtml.includes("../script.js?v=20260620-primary-nav"));
 assert(html.includes("Repeatable AI Agent Workflows"));
 assert(html.includes('rel="sitemap"'));
@@ -1016,6 +1016,8 @@ assert(css.includes(".agent-resource-grid"));
 assert(css.includes(".agent-install-block"));
 assert(css.includes(".article-guide"));
 assert(css.includes(".article-header"));
+assert(css.includes("width: min(100%, 1180px)"));
+assert(css.includes(".article-header + .article-section"));
 assert(css.includes(".article-section"));
 assert(css.includes(".section-icon"));
 assert(!css.includes(".learning-hero"));

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -76,7 +76,7 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260620-primary-nav" />
+    <link rel="stylesheet" href="../styles.css?v=20260620-article-layout" />
     <script src="../script.js?v=20260620-primary-nav" defer></script>
     <script type="application/ld+json">
       {

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -74,7 +74,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260620-primary-nav" />
+    <link rel="stylesheet" href="../styles.css?v=20260620-article-layout" />
     <script src="../script.js?v=20260620-primary-nav" defer></script>
     <script type="application/ld+json">
       {

--- a/site/styles.css
+++ b/site/styles.css
@@ -1508,16 +1508,16 @@ code {
 
 /* Plain article learning guide */
 .article-guide {
-  width: min(100%, 940px);
+  width: min(100%, 1180px);
 }
 
 .article-header {
   padding-top: clamp(72px, 9vw, 120px);
-  padding-bottom: clamp(56px, 7vw, 80px);
+  padding-bottom: clamp(24px, 3vw, 40px);
 }
 
 .article-header h1 {
-  max-width: 860px;
+  max-width: 1060px;
   margin-bottom: 28px;
   font-size: clamp(3.5rem, 7vw, 6.25rem);
   font-weight: 800;
@@ -1527,7 +1527,7 @@ code {
 
 .article-header p,
 .article-section p {
-  max-width: 760px;
+  max-width: 980px;
   color: var(--muted);
   font-size: 1rem;
   line-height: 1.75;
@@ -1547,11 +1547,15 @@ code {
   margin-top: clamp(64px, 8vw, 96px);
 }
 
+.article-header + .article-section {
+  margin-top: clamp(32px, 4vw, 48px);
+}
+
 .article-section h2 {
   display: flex;
   align-items: center;
   gap: 13px;
-  max-width: 760px;
+  max-width: 980px;
   margin-bottom: 24px;
   font-size: clamp(2.15rem, 4vw, 3.4rem);
   font-weight: 800;
@@ -1578,7 +1582,7 @@ code {
 }
 
 .article-section h3 {
-  max-width: 760px;
+  max-width: 980px;
   margin-top: 48px;
   margin-bottom: 12px;
   font-size: clamp(1.4rem, 2.4vw, 1.85rem);
@@ -1623,12 +1627,12 @@ code {
 }
 
 .agent-start-card [data-prompt] {
-  max-width: 820px;
+  max-width: 980px;
 }
 
 .agent-steps {
   display: grid;
-  max-width: 820px;
+  max-width: 980px;
   padding: 0;
   margin: 0;
   counter-reset: agent-step;
@@ -1661,7 +1665,7 @@ code {
 
 .agent-resource-grid {
   display: grid;
-  max-width: 820px;
+  max-width: 980px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   border-top: 1px solid var(--ink);
   border-left: 1px solid var(--ink);
@@ -1704,7 +1708,7 @@ code {
 }
 
 .agent-install-block {
-  max-width: 820px;
+  max-width: 980px;
   padding: 20px 22px;
   margin: 24px 0;
   overflow-x: auto;


### PR DESCRIPTION
## What changed
- widened the shared article layout used by Learn and For agents
- increased readable content widths for headings, body copy, agent steps, cards, and resource grids
- reduced the compounded gap between the Learn introduction and its first section
- cache-busted the stylesheet on both affected pages and added regression assertions

## Why
The Learn and For agents pages were constrained to a narrow desktop column, and Learn stacked header padding with section margin to create an oversized empty gap after the introduction.

## Validation
- `node scripts/check.mjs`
- JavaScript syntax checks for site and build scripts
- `npm --prefix worker run check` (14 tests)
- JSON validation for site data and SEO benchmark
- `git diff --check`