### PR TITLE
[codex] Clarify loop submission publication rights

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -932,6 +932,12 @@ assert(html.includes('id="theme-toggle"'));
 assert(html.includes('document.documentElement.dataset.theme = theme'));
 assert(html.includes('"loop-library-theme"'));
 assert(html.includes('id="loop-form"'));
+assert(
+  html.includes(
+    "I confirm that I own this loop and grant Loop Library a\n" +
+      "              non-exclusive license to edit, reproduce, and publish it.",
+  ),
+);
 assert(html.includes('id="weekly"'));
 assert(html.includes('id="weekly-form"'));
 assert(html.includes("One useful loop, once a week."));

--- a/site/index.html
+++ b/site/index.html
@@ -2399,8 +2399,8 @@
           <label class="consent-field">
             <input name="permission" type="checkbox" required />
             <span>
-              I have the right to share this and understand it may be edited
-              for clarity.
+              I confirm that I own this loop and grant Loop Library a
+              non-exclusive license to edit, reproduce, and publish it.
             </span>
           </label>
 


### PR DESCRIPTION
## What changed

- Updated the required submission consent to confirm the submitter owns the loop.
- Added an explicit non-exclusive license for Loop Library to edit, reproduce, and publish the loop.
- Added a repository assertion that protects the disclosure from accidental removal.

## Why

The previous language only said the submitter had the right to share the loop. It did not expressly confirm ownership or grant Loop Library publication rights.

## Validation

- Full generated-artifact checks
- SEO/GEO audit: no critical, high, or medium findings
- Worker test suite: 14 passing
- here.now branding validator: 47 pages passing
- Auto Review: clean, no actionable findings