### PR TITLE
Fix library search matching interface control text

### DIFF
--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -77,7 +77,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260621-author-byline" />
-    <script src="../script.js?v=20260622-retry-after" defer></script>
+    <script src="../script.js?v=20260622-search-index" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/index.html
+++ b/site/index.html
@@ -198,7 +198,7 @@
   ]
 }
     </script>
-    <script src="./script.js?v=20260622-retry-after" defer></script>
+    <script src="./script.js?v=20260622-search-index" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -75,7 +75,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260621-author-byline" />
-    <script src="../script.js?v=20260622-retry-after" defer></script>
+    <script src="../script.js?v=20260622-search-index" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/script.js
+++ b/site/script.js
@@ -100,6 +100,16 @@ if (loopTableBody) {
   loopRows.forEach((row) => loopTableBody.append(row));
 }
 
+// Snapshot each row's searchable text before the prompt toggle is injected
+// below. Read the loop content rather than the whole row so search does not
+// match interface controls such as "Copy loop" or "Show more".
+const rowSearchText = new Map(
+  loopRows.map((row) => {
+    const content = row.querySelector(".cell-loop") ?? row;
+    return [row, normalize(`${row.dataset.search ?? ""} ${content.textContent}`)];
+  }),
+);
+
 const promptPreviews = loopRows
   .map((row, index) => {
     const prompt = row.querySelector("[data-prompt]");
@@ -173,9 +183,9 @@ function updateLibrary() {
 
   const query = normalize(searchInput.value);
   const matchingRows = loopRows.filter((row) => {
-    const searchableText = `${row.dataset.search} ${row.textContent}`;
+    const searchableText = rowSearchText.get(row) ?? "";
     const matchesSearch =
-      query.length === 0 || normalize(searchableText).includes(query);
+      query.length === 0 || searchableText.includes(query);
     const matchesCategory =
       activeCategory === "all" || row.dataset.category === activeCategory;
     return matchesSearch && matchesCategory;


### PR DESCRIPTION
## Summary

The homepage library search matched interface control text, so several common words filtered nothing.

`updateLibrary()` built each row's search haystack from the entire row's `textContent`:

```js
const searchableText = `${row.dataset.search} ${row.textContent}`;
```

A loop row's `textContent` includes the **"Copy loop"** action button, and — after `script.js` runs — the injected **"Show more" / "Show less"** prompt toggle. Because every row contains those strings, typing `copy`, `show`, `more`, or `less` matched **all** loops instead of filtering them.

## Fix

Snapshot each row's searchable text once at load, reading the `.cell-loop` content (category, attribution, title, summary, and prompt) **before** the prompt toggle button is inserted. The cached, pre-normalized value is then reused on every keystroke.

This:
- excludes the `.cell-action` "Copy loop" button and the injected toggle from the search index,
- keeps title / summary / prompt / `data-search` keyword matching fully intact, and
- avoids re-reading `textContent` for all rows on every keystroke.

## Verification

- Before: search `copy` or `show` → all 44 loops shown. After: those words match only loops whose content actually contains them.
- `node scripts/check.mjs` → `Loop Library checks passed.`
- `node --check site/script.js`
- `node scripts/build-skill-catalog.mjs && node scripts/build-loop-pages.mjs && node scripts/build-social-images.mjs` → no artifact drift (`git status` clean apart from `site/script.js`).
- `npm --prefix worker run check` → tests pass.
