### PR TITLE
Add a clear search and filters action to the empty state

### DIFF
--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -76,8 +76,8 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260621-author-byline" />
-    <script src="../script.js?v=20260622-search-index" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260622-empty-state" />
+    <script src="../script.js?v=20260622-empty-state" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260621-author-byline" />
+    <link rel="stylesheet" href="./styles.css?v=20260622-empty-state" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -198,7 +198,7 @@
   ]
 }
     </script>
-    <script src="./script.js?v=20260622-search-index" defer></script>
+    <script src="./script.js?v=20260622-empty-state" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>
@@ -451,7 +451,12 @@
         <div class="empty-state" id="empty-state" hidden>
           <h3>No matching loops</h3>
           <p>Try another category, broaden your search, or submit the workflow.</p>
-          <a href="#submit">Submit a loop</a>
+          <div class="empty-state-actions">
+            <button class="empty-state-reset" id="clear-filters" type="button">
+              Clear search &amp; filters
+            </button>
+            <a href="#submit">Submit a loop</a>
+          </div>
         </div>
 
         <nav

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -74,8 +74,8 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260621-author-byline" />
-    <script src="../script.js?v=20260622-search-index" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260622-empty-state" />
+    <script src="../script.js?v=20260622-empty-state" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/script.js
+++ b/site/script.js
@@ -270,6 +270,28 @@ categoryFilters.forEach((filter) => {
   });
 });
 
+const clearFiltersButton = document.querySelector("#clear-filters");
+
+if (clearFiltersButton) {
+  clearFiltersButton.addEventListener("click", () => {
+    if (searchInput) {
+      searchInput.value = "";
+    }
+
+    activeCategory = "all";
+    currentPage = 1;
+
+    categoryFilters.forEach((candidate) => {
+      const isActive = candidate.dataset.categoryFilter === "all";
+      candidate.classList.toggle("is-active", isActive);
+      candidate.setAttribute("aria-pressed", String(isActive));
+    });
+
+    updateLibrary();
+    searchInput?.focus();
+  });
+}
+
 if (paginationPrevious) {
   paginationPrevious.addEventListener("click", () => {
     if (currentPage > 1) {

--- a/site/styles.css
+++ b/site/styles.css
@@ -884,6 +884,38 @@ code {
   font-weight: 700;
 }
 
+.empty-state-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.empty-state-reset {
+  padding: 8px 12px;
+  border: 1px solid var(--ink);
+  color: var(--ink);
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.empty-state-reset:hover,
+.empty-state-reset:focus-visible {
+  color: var(--solid-foreground);
+  background: var(--solid-background);
+}
+
+.empty-state-reset:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
 .pagination {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

When a search query or category filter matches no loops, the empty state reads:

> Try another category, broaden your search, or submit the workflow.

…but offers no direct way to actually do that. The only ways back to the full catalog are manually clearing the search box or hunting for the **All** category chip — extra friction at exactly the dead-end moment.

This adds a **Clear search & filters** button to the empty state that:

- clears the search input,
- resets the active category to **All** (updating the chip `is-active` / `aria-pressed` state),
- resets pagination to page 1 and re-renders the full catalog, and
- returns focus to the search box so keyboard users can immediately type a new query.

## Changes

- `site/index.html` — wrap the empty-state actions and add the reset button.
- `site/script.js` — wire the button to reset query + category and refocus search.
- `site/styles.css` — style the button to match the existing pagination/control buttons (including `:focus-visible`).

## Verification

- `node scripts/check.mjs` → `Loop Library checks passed.`
- `node --check site/script.js`
- Builders (`build-skill-catalog`, `build-loop-pages`, `build-social-images`) → no artifact drift.
