### PR TITLE
Surface Retry-After so rate-limited visitors know when to retry

### DIFF
--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -77,7 +77,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260621-author-byline" />
-    <script src="../script.js?v=20260621-author-byline" defer></script>
+    <script src="../script.js?v=20260622-retry-after" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/index.html
+++ b/site/index.html
@@ -198,7 +198,7 @@
   ]
 }
     </script>
-    <script src="./script.js?v=20260621-author-byline" defer></script>
+    <script src="./script.js?v=20260622-retry-after" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -75,7 +75,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260621-author-byline" />
-    <script src="../script.js?v=20260621-author-byline" defer></script>
+    <script src="../script.js?v=20260622-retry-after" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/script.js
+++ b/site/script.js
@@ -677,6 +677,20 @@ async function initializeFormProtection() {
   }
 }
 
+function formatRetryHint(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "";
+  }
+
+  if (seconds < 90) {
+    const rounded = Math.max(1, Math.ceil(seconds));
+    return ` Try again in about ${rounded} second${rounded === 1 ? "" : "s"}.`;
+  }
+
+  const minutes = Math.max(1, Math.ceil(seconds / 60));
+  return ` Try again in about ${minutes} minute${minutes === 1 ? "" : "s"}.`;
+}
+
 async function postProtectedForm(path, body, fallbackMessage) {
   const response = await fetch(`${FORM_API_ORIGIN}${path}`, {
     method: "POST",
@@ -695,9 +709,13 @@ async function postProtectedForm(path, body, fallbackMessage) {
   }
 
   if (!response.ok) {
-    throw new Error(
-      responseBody.error || fallbackMessage,
-    );
+    let message = responseBody.error || fallbackMessage;
+
+    if (response.status === 429) {
+      message += formatRetryHint(Number(response.headers.get("Retry-After")));
+    }
+
+    throw new Error(message);
   }
 }
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -345,6 +345,7 @@ function getCorsHeaders(origin, env) {
 
   return {
     "Access-Control-Allow-Origin": origin,
+    "Access-Control-Expose-Headers": "Retry-After",
     "Cache-Control": "no-store",
     Vary: "Origin",
   };

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -370,6 +370,10 @@ test("rate limits invalid-token floods before calling Siteverify", async () => {
 
   assert.equal(response.status, 429);
   assert.equal(response.headers.get("Retry-After"), "60");
+  assert.equal(
+    response.headers.get("Access-Control-Expose-Headers"),
+    "Retry-After",
+  );
   assert.equal(body.code, "rate_limited");
   assert.deepEqual(rateLimitCalls, ["suggestions:203.0.113.10"]);
   assert.equal(calls.turnstile.length, 0);


### PR DESCRIPTION
## Summary

The form gateway already computes and returns a `Retry-After` header on `429` responses (both the verification rate limiter and the per-IP hourly/daily limiter), but it never reached the visitor:

1. **The Worker didn't expose it.** `Retry-After` is not a [CORS-safelisted response header](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header), so a cross-origin `fetch()` from the site can't read it unless it's listed in `Access-Control-Expose-Headers` — which it wasn't.
2. **The client ignored it anyway.** `postProtectedForm()` surfaced only `responseBody.error`, so a rate-limited visitor saw "Try again later" with no sense of how long.

## Fix

- **Worker** (`worker/src/index.js`): add `Access-Control-Expose-Headers: Retry-After` to the CORS headers so the browser can read it.
- **Client** (`site/script.js`): on a `429`, read `Retry-After` and append a concrete hint — e.g. "Try again in about 1 minute." — to the existing status message.
- **Test** (`worker/test/index.test.js`): assert the header is exposed on rate-limited responses.

The hint formatting is defensive: a missing or non-numeric header simply yields no hint, preserving today's behavior.

## Verification

- `npm --prefix worker run check` → 14/14 tests pass.
- `node scripts/check.mjs` → `Loop Library checks passed.`
- `node --check site/script.js`
- Builders → no artifact drift.
