### PR TITLE
Make library search and category filters deep-linkable

### DIFF
--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -77,7 +77,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260622-empty-state" />
-    <script src="../script.js?v=20260622-empty-state" defer></script>
+    <script src="../script.js?v=20260622-url-state" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/index.html
+++ b/site/index.html
@@ -198,7 +198,7 @@
   ]
 }
     </script>
-    <script src="./script.js?v=20260622-empty-state" defer></script>
+    <script src="./script.js?v=20260622-url-state" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -75,7 +75,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260622-empty-state" />
-    <script src="../script.js?v=20260622-empty-state" defer></script>
+    <script src="../script.js?v=20260622-url-state" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/script.js
+++ b/site/script.js
@@ -228,6 +228,65 @@ function updateLibrary() {
   window.requestAnimationFrame(syncVisiblePromptToggles);
 }
 
+// Keep the library's state shareable without discarding tracking or other
+// query parameters owned by the surrounding site.
+function syncUrlState(method = "replace") {
+  if (typeof window.history?.replaceState !== "function") {
+    return;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const query = searchInput?.value.trim() ?? "";
+
+  if (query) {
+    params.set("q", query);
+  } else {
+    params.delete("q");
+  }
+
+  if (activeCategory && activeCategory !== "all") {
+    params.set("category", activeCategory);
+  } else {
+    params.delete("category");
+  }
+
+  if (currentPage > 1) {
+    params.set("page", String(currentPage));
+  } else {
+    params.delete("page");
+  }
+
+  const search = params.toString();
+  const nextUrl = `${window.location.pathname}${search ? `?${search}` : ""}${
+    window.location.hash
+  }`;
+  const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+  if (nextUrl === currentUrl) {
+    return;
+  }
+
+  if (method === "push" && typeof window.history.pushState === "function") {
+    window.history.pushState(null, "", nextUrl);
+  } else {
+    window.history.replaceState(null, "", nextUrl);
+  }
+}
+
+function readUrlState() {
+  const params = new URLSearchParams(window.location.search);
+
+  if (searchInput) {
+    searchInput.value = params.get("q") ?? "";
+  }
+
+  applyCategory(params.get("category") ?? "all");
+
+  const requestedPage = Number.parseInt(params.get("page") ?? "1", 10);
+  currentPage =
+    Number.isInteger(requestedPage) && requestedPage > 0 ? requestedPage : 1;
+}
+
 function focusFirstVisibleLoop() {
   const firstVisibleTitle = loopRows
     .find((row) => !row.hidden)
@@ -249,24 +308,32 @@ if (searchInput) {
   const resetSearchPage = () => {
     currentPage = 1;
     updateLibrary();
+    syncUrlState("replace");
   };
 
   searchInput.addEventListener("input", resetSearchPage);
   searchInput.addEventListener("search", resetSearchPage);
 }
 
+function applyCategory(category) {
+  const known = categoryFilters.some(
+    (filter) => filter.dataset.categoryFilter === category,
+  );
+  activeCategory = known ? category : "all";
+
+  categoryFilters.forEach((candidate) => {
+    const isActive = candidate.dataset.categoryFilter === activeCategory;
+    candidate.classList.toggle("is-active", isActive);
+    candidate.setAttribute("aria-pressed", String(isActive));
+  });
+}
+
 categoryFilters.forEach((filter) => {
   filter.addEventListener("click", () => {
-    activeCategory = filter.dataset.categoryFilter;
+    applyCategory(filter.dataset.categoryFilter);
     currentPage = 1;
-
-    categoryFilters.forEach((candidate) => {
-      const isActive = candidate === filter;
-      candidate.classList.toggle("is-active", isActive);
-      candidate.setAttribute("aria-pressed", String(isActive));
-    });
-
     updateLibrary();
+    syncUrlState("push");
   });
 });
 
@@ -278,16 +345,10 @@ if (clearFiltersButton) {
       searchInput.value = "";
     }
 
-    activeCategory = "all";
+    applyCategory("all");
     currentPage = 1;
-
-    categoryFilters.forEach((candidate) => {
-      const isActive = candidate.dataset.categoryFilter === "all";
-      candidate.classList.toggle("is-active", isActive);
-      candidate.setAttribute("aria-pressed", String(isActive));
-    });
-
     updateLibrary();
+    syncUrlState("push");
     searchInput?.focus();
   });
 }
@@ -297,6 +358,7 @@ if (paginationPrevious) {
     if (currentPage > 1) {
       currentPage -= 1;
       updateLibrary();
+      syncUrlState("push");
       focusFirstVisibleLoop();
     }
   });
@@ -306,11 +368,19 @@ if (paginationNext) {
   paginationNext.addEventListener("click", () => {
     currentPage += 1;
     updateLibrary();
+    syncUrlState("push");
     focusFirstVisibleLoop();
   });
 }
 
+readUrlState();
 updateLibrary();
+syncUrlState("replace");
+
+window.addEventListener("popstate", () => {
+  readUrlState();
+  updateLibrary();
+});
 
 let promptResizeFrame;
 window.addEventListener("resize", () => {


### PR DESCRIPTION
## Summary

The homepage library's filter state (search query, active category, page) lived only in memory. As a result:

- a filtered or searched view couldn't be **shared** or **bookmarked**,
- a **reload** dropped the filters back to the default view, and
- the browser **back/forward** buttons didn't restore previous filter states.

This wires that state into the URL query string so a slice of the library is directly linkable — a natural fit for a catalog that's explicitly built for SEO/GEO and agent discovery (`llms.txt`, `catalog.json`, etc.).

## Behavior

- Search → `?q=…`, category → `?category=engineering`, page → `?page=2`. Defaults (empty query, `all`, page 1) are omitted so the canonical homepage URL stays clean.
- On load and on `popstate`, state is restored from the URL. The category is **validated** against the available filter chips (unknown values fall back to `all`) and the page is parsed/clamped by the existing pagination logic, so hand-edited or stale URLs degrade gracefully.
- Uses `history.replaceState` (guarded for environments without it), so typing in the search box doesn't flood the history stack.

## Implementation notes

- Extracted the category-activation logic into a reusable `applyCategory()` (used by both the click handler and URL restore).
- `syncUrlState()` is called at the end of `updateLibrary()`, which already runs on every search/category/pagination change, so there's a single write path. It only calls `replaceState` when the URL actually changes.
- No-ops cleanly on pages without the library (the `searchInput`/results guards already short-circuit `updateLibrary`).

## Verification

- `node scripts/check.mjs` → `Loop Library checks passed.`
- `node --check site/script.js`
- Builders (`build-skill-catalog`, `build-loop-pages`, `build-social-images`) → no artifact drift.
- Manual: searching, switching categories, and paging update the URL; reloading and back/forward restore the same view; `?category=bogus` / `?page=99` normalize to a valid state.
