### PR TITLE
Make loop author attribution visible

### DIFF
--- a/scripts/build-loop-pages.mjs
+++ b/scripts/build-loop-pages.mjs
@@ -404,7 +404,7 @@ ${structuredData(loop)}
           <h1>${escapeHtml(loop.title)}</h1>
           <p class="detail-lede">${escapeHtml(loop.description)}</p>
           <p class="detail-byline">
-            Contributed by <strong>${escapeHtml(loop.author)}</strong>
+            By <strong>${escapeHtml(loop.author)}</strong>
           </p>
           ${shareActions(loop, url)}
         </header>

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -630,7 +630,7 @@ for (const [index, loop] of loops.entries()) {
   assert(page.includes(loop.description));
   assert(page.includes(escapeHtml(loop.prompt)));
   assert(page.includes(`<p class="eyebrow">Loop ${loop.number}</p>`));
-  assert(page.includes(`Contributed by <strong>${loop.author}</strong>`));
+  assert(page.includes(`By <strong>${loop.author}</strong>`));
   assert(page.includes(escapeHtml(loop.verifyTitle)));
   assert(page.includes(escapeHtml(loop.verifyDetail)));
   assert(page.includes(escapeHtml(loop.useWhen)));

--- a/site/loops/100-percent-test-coverage-loop/index.html
+++ b/site/loops/100-percent-test-coverage-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The 100% test coverage loop</h1>
           <p class="detail-lede">A goal-based coding-agent workflow that identifies uncovered behavior, adds meaningful tests, and stops when the full suite passes at 100% coverage.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/accessibility-repair-loop/index.html
+++ b/site/loops/accessibility-repair-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The accessibility repair loop</h1>
           <p class="detail-lede">An accessibility review that confirms barriers against an agreed standard, fixes the issue with the greatest user impact, and repeats the same checks.</p>
           <p class="detail-byline">
-            Contributed by <strong>Eric Lott</strong>
+            By <strong>Eric Lott</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/architecture-satisfaction-loop/index.html
+++ b/site/loops/architecture-satisfaction-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The architecture satisfaction loop</h1>
           <p class="detail-lede">A bounded refactoring workflow that live-tests the system, runs an independent review, commits checkpoints, and records progress.</p>
           <p class="detail-byline">
-            Contributed by <strong>Peter Steinberger</strong>
+            By <strong>Peter Steinberger</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/artifact-to-skill-loop/index.html
+++ b/site/loops/artifact-to-skill-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The artifact-to-skill loop</h1>
           <p class="detail-lede">A reusable workflow for turning one proven artifact into a transferable skill, playbook, or procedure and validating it on a second case.</p>
           <p class="detail-byline">
-            Contributed by <strong>Hiten Shah (@hnshah)</strong>
+            By <strong>Hiten Shah (@hnshah)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/autonomy-loop/index.html
+++ b/site/loops/autonomy-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The autonomy-loop builder-reviewer loop</h1>
           <p class="detail-lede">An autonomy-loop workflow in which a builder and adversarial reviewer pass a git baton between worktrees and prove each new test can catch its fix.</p>
           <p class="detail-byline">
-            Contributed by <strong>@inferencegod</strong>
+            By <strong>@inferencegod</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/axelrod-subagent-arena-loop/index.html
+++ b/site/loops/axelrod-subagent-arena-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Axelrod subagent arena loop</h1>
           <p class="detail-lede">A controlled tournament where two reasoning AI agents repeatedly choose to cooperate or defect, then are compared with players that always make one choice.</p>
           <p class="detail-byline">
-            Contributed by <strong>Kan Yuenyong (@sikkha)</strong>
+            By <strong>Kan Yuenyong (@sikkha)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/boeing-747-benchmark/index.html
+++ b/site/loops/boeing-747-benchmark/index.html
@@ -211,7 +211,7 @@
           <h1>The Boeing 747 benchmark</h1>
           <p class="detail-lede">A vision benchmark in which an agent builds a Boeing 747 from Three.js primitives, renders nine repeatable angles, and fixes what each view reveals.</p>
           <p class="detail-byline">
-            Contributed by <strong>@victormustar</strong>
+            By <strong>@victormustar</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/clodex-adversarial-review-loop/index.html
+++ b/site/loops/clodex-adversarial-review-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Clodex adversarial-review loop</h1>
           <p class="detail-lede">A Claude-and-Codex workflow that opens a pull request, runs an independent Codex review, fixes blocking findings, and repeats.</p>
           <p class="detail-byline">
-            Contributed by <strong>Lukas Kucinski</strong>
+            By <strong>Lukas Kucinski</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/codex-completion-contract-loop/index.html
+++ b/site/loops/codex-completion-contract-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Codex completion-contract loop</h1>
           <p class="detail-lede">A goal-planner-codex workflow that defines completion up front, tracks proof for every requirement, and prevents partial Codex work from being reported as done.</p>
           <p class="detail-byline">
-            Contributed by <strong>3goblack (@Dis_Trackted)</strong>
+            By <strong>3goblack (@Dis_Trackted)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/cold-load-trimmer-loop/index.html
+++ b/site/loops/cold-load-trimmer-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The cold-load trimmer loop</h1>
           <p class="detail-lede">A web performance workflow that reduces the data downloaded before the first screen appears, while tests and screenshots protect behavior and appearance.</p>
           <p class="detail-byline">
-            Contributed by <strong>Christian Katzmann</strong>
+            By <strong>Christian Katzmann</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/customer-ai-deployment-loop/index.html
+++ b/site/loops/customer-ai-deployment-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The customer AI deployment loop</h1>
           <p class="detail-lede">A supervised delivery workflow that advances one customer priority into a validated, gradually released AI system with monitoring, approvals, and outcome evidence.</p>
           <p class="detail-byline">
-            Contributed by <strong>AgentLed.ai Agent</strong>
+            By <strong>AgentLed.ai Agent</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/devils-advocate-design-loop/index.html
+++ b/site/loops/devils-advocate-design-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The devil&#39;s-advocate loop</h1>
           <p class="detail-lede">A critic-and-builder workflow that attacks a design, tracks every objection, and requires evidence before an objection can be closed.</p>
           <p class="detail-byline">
-            Contributed by <strong>Anonymous contributor</strong>
+            By <strong>Anonymous contributor</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/easy-onboarding-loop/index.html
+++ b/site/loops/easy-onboarding-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The easy onboarding loop</h1>
           <p class="detail-lede">A first-time-user test that starts with no saved account or browser state, fixes one confirmed onboarding obstacle, and retries the entire experience.</p>
           <p class="detail-byline">
-            Contributed by <strong>Eric Lott</strong>
+            By <strong>Eric Lott</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/exhaustive-logging-coverage-loop/index.html
+++ b/site/loops/exhaustive-logging-coverage-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The logging coverage loop</h1>
           <p class="detail-lede">A goal-based observability workflow that audits important paths, adds useful structured logs, and verifies success and failure events with tests.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/five-minute-repository-maintainer-loop/index.html
+++ b/site/loops/five-minute-repository-maintainer-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The five-minute repository maintainer loop</h1>
           <p class="detail-lede">A five-minute Codex workflow that triages repositories, directs bounded maintenance to dedicated threads, and requires proof and permission before work lands.</p>
           <p class="detail-byline">
-            Contributed by <strong>Peter Steinberger</strong>
+            By <strong>Peter Steinberger</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/fresh-clone-loop/index.html
+++ b/site/loops/fresh-clone-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The fresh-clone loop</h1>
           <p class="detail-lede">A disposable-environment workflow that follows the README from scratch, fixes every hidden setup assumption, and restarts until onboarding works cleanly.</p>
           <p class="detail-byline">
-            Contributed by <strong>0xUmbra</strong>
+            By <strong>0xUmbra</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/full-product-evaluation-loop/index.html
+++ b/site/loops/full-product-evaluation-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The full product evaluation loop</h1>
           <p class="detail-lede">A comprehensive product-quality workflow that evaluates realistic scenarios across every major capability, fixes weak outcomes, and reruns them to the defined bar.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/goal-forge-loop/index.html
+++ b/site/loops/goal-forge-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Goal Forge loop</h1>
           <p class="detail-lede">A planning workflow that interviews the user, writes what should be built in SPEC.md, and writes how Codex should execute and verify it in GOAL.md.</p>
           <p class="detail-byline">
-            Contributed by <strong>michael Guo (@michaelzsguo)</strong>
+            By <strong>michael Guo (@michaelzsguo)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/groundtruth-audit-loop/index.html
+++ b/site/loops/groundtruth-audit-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Groundtruth loop</h1>
           <p class="detail-lede">A read-only project-audit workflow that verifies architecture, security, platform behavior, operations, and business logic from current evidence rather than assumptions.</p>
           <p class="detail-byline">
-            Contributed by <strong>Mohamed (@aivibecode)</strong>
+            By <strong>Mohamed (@aivibecode)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/housekeeper-loop/index.html
+++ b/site/loops/housekeeper-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The housekeeper loop</h1>
           <p class="detail-lede">A conservative code-project cleanup that proves one small opportunity is safe, makes the smallest useful change, and keeps it only after existing checks pass.</p>
           <p class="detail-byline">
-            Contributed by <strong>Eric Lott</strong>
+            By <strong>Eric Lott</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/infinite-clickbait-loop/index.html
+++ b/site/loops/infinite-clickbait-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Infinite Clickbait thumbnail loop</h1>
           <p class="detail-lede">A thumbnail workflow that creates ten concepts, scores the top three against a relevant YouTube channel, and improves the winner without misleading viewers.</p>
           <p class="detail-byline">
-            Contributed by <strong>@Alex_FF</strong>
+            By <strong>@Alex_FF</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/living-story-loop/index.html
+++ b/site/loops/living-story-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Living Story loop</h1>
           <p class="detail-lede">A recurring context-maintenance workflow that turns repository activity, goals, and prior open threads into a verified daily story for future agents.</p>
           <p class="detail-byline">
-            Contributed by <strong>Buddy Hadry (@buddyhadry)</strong>
+            By <strong>Buddy Hadry (@buddyhadry)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/loop-harness-verification-loop/index.html
+++ b/site/loops/loop-harness-verification-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Loop Harness verification loop</h1>
           <p class="detail-lede">A scheduled Loop Harness workflow that runs Claude in an isolated worktree and ships staged output only after a second Claude session verifies it.</p>
           <p class="detail-byline">
-            Contributed by <strong>Istasha</strong>
+            By <strong>Istasha</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/multi-llm-convergence-loop/index.html
+++ b/site/loops/multi-llm-convergence-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The multi-LLM convergence loop</h1>
           <p class="detail-lede">Alternates two AI systems from different providers to review a plan, document, or code change until both approve the exact same version.</p>
           <p class="detail-byline">
-            Contributed by <strong>Donn Felker (@donnfelker)</strong>
+            By <strong>Donn Felker (@donnfelker)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/nightly-changelog-sweep/index.html
+++ b/site/loops/nightly-changelog-sweep/index.html
@@ -211,7 +211,7 @@
           <h1>The nightly changelog loop</h1>
           <p class="detail-lede">A scheduled coding-agent workflow that reviews the previous day&#39;s changes and keeps user-facing release history complete and current.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/overnight-docs-sweep/index.html
+++ b/site/loops/overnight-docs-sweep/index.html
@@ -211,7 +211,7 @@
           <h1>The docs sweep</h1>
           <p class="detail-lede">A reusable AI coding-agent workflow for comparing documentation with the current codebase, fixing drift, and opening a reviewable pull request.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/pixel-safe-css-trim-loop/index.html
+++ b/site/loops/pixel-safe-css-trim-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The pixel-safe CSS trim loop</h1>
           <p class="detail-lede">A stylesheet cleanup workflow that removes one piece of unused or redundant CSS at a time and keeps it removed only when every tested screen looks identical.</p>
           <p class="detail-byline">
-            Contributed by <strong>Christian Katzmann</strong>
+            By <strong>Christian Katzmann</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/post-release-baseline-loop/index.html
+++ b/site/loops/post-release-baseline-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The post-release baseline loop</h1>
           <p class="detail-lede">A triggered release workflow that runs standard benchmarks against the completed release and records a reproducible baseline for future comparisons.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/prepare-new-project-loop/index.html
+++ b/site/loops/prepare-new-project-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The prepare-a-new-project loop</h1>
           <p class="detail-lede">A planning workflow that closes documentation gaps until requirements, technical design, acceptance criteria, and test strategy describe one buildable system.</p>
           <p class="detail-byline">
-            Contributed by <strong>Brad Shannon (@bradshannon)</strong>
+            By <strong>Brad Shannon (@bradshannon)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/product-update-podcast-loop/index.html
+++ b/site/loops/product-update-podcast-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The product update podcast loop</h1>
           <p class="detail-lede">A scheduled editorial workflow that turns meaningful public product changes into a short, source-grounded podcast episode.</p>
           <p class="detail-byline">
-            Contributed by <strong>Pierson Marks</strong>
+            By <strong>Pierson Marks</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/production-data-cleanup-loop/index.html
+++ b/site/loops/production-data-cleanup-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The production data cleanup loop</h1>
           <p class="detail-lede">A production-data quality workflow that removes disallowed records, improves classification logic, and verifies the remaining dataset against an explicit definition.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/production-error-sweep/index.html
+++ b/site/loops/production-error-sweep/index.html
@@ -211,7 +211,7 @@
           <h1>The production error sweep</h1>
           <p class="detail-lede">A scheduled production-log workflow that traces actionable errors to root causes, verifies fixes, opens a pull request, and stops cleanly when no action is needed.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/promise-to-proof-loop/index.html
+++ b/site/loops/promise-to-proof-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The promise-to-proof loop</h1>
           <p class="detail-lede">A product review that compares claims in marketing, documentation, demos, and AI answers with current evidence, then fixes or narrows unsupported promises.</p>
           <p class="detail-byline">
-            Contributed by <strong>Felix Haeberle (@felixhaberle)</strong>
+            By <strong>Felix Haeberle (@felixhaberle)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/propagation-compliance-loop/index.html
+++ b/site/loops/propagation-compliance-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The propagation compliance loop</h1>
           <p class="detail-lede">A consistency check for values copied across a code project: update every affected copy, find leftovers, and prove that only intentional old references remain.</p>
           <p class="detail-byline">
-            Contributed by <strong>@iamTristan</strong>
+            By <strong>@iamTristan</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/quality-streak-loop/index.html
+++ b/site/loops/quality-streak-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The quality streak loop</h1>
           <p class="detail-lede">A realistic product-testing workflow that turns every failure into documented regression coverage and restarts the success streak after each fix.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/recent-feedback-sweep/index.html
+++ b/site/loops/recent-feedback-sweep/index.html
@@ -211,7 +211,7 @@
           <h1>The recent-feedback sweep</h1>
           <p class="detail-lede">A project audit that turns recent user-reported problems into reusable failure patterns, fixes every confirmed match, and verifies a clean final sweep.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/recovery-proof-loop/index.html
+++ b/site/loops/recovery-proof-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Recovery Proof loop</h1>
           <p class="detail-lede">A disaster-recovery validation workflow that restores randomly selected real recovery points, verifies integrity and RPO/RTO, and preserves failures as regression drills.</p>
           <p class="detail-byline">
-            Contributed by <strong>Eric Lott</strong>
+            By <strong>Eric Lott</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/repository-cleanup-loop/index.html
+++ b/site/loops/repository-cleanup-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The repository cleanup loop</h1>
           <p class="detail-lede">A repository-hygiene workflow that audits branches, pull requests, commits, and worktrees, recovers valuable changes, and removes proven stale state.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/revolve-self-improvement-loop/index.html
+++ b/site/loops/revolve-self-improvement-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Revolve versioned-experiment loop</h1>
           <p class="detail-lede">A Revolve workflow that improves prompts, code, or configurations through checkpointed experiments whose scores remain comparable across sessions.</p>
           <p class="detail-byline">
-            Contributed by <strong>Agent Zero</strong>
+            By <strong>Agent Zero</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/self-improving-champion-loop/index.html
+++ b/site/loops/self-improving-champion-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The self-improving champion loop</h1>
           <p class="detail-lede">A prompt-optimization workflow that tests challengers on a working set, promotes only fresh holdout wins, and keeps the current champion on uncertainty.</p>
           <p class="detail-byline">
-            Contributed by <strong>Jose C. Munoz</strong>
+            By <strong>Jose C. Munoz</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/seo-geo-visibility-loop/index.html
+++ b/site/loops/seo-geo-visibility-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The SEO/GEO visibility loop</h1>
           <p class="detail-lede">A repeatable search visibility workflow that fixes the highest-impact crawl, indexation, page-intent, citation, and answer-readiness gaps first.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/stale-safe-batch-release-loop/index.html
+++ b/site/loops/stale-safe-batch-release-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The stale-safe batch release loop</h1>
           <p class="detail-lede">A release-coordination workflow that excludes stale or unfinished work, combines valid changes, and ships complete artifacts from the latest integrated main.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/strip-miner-loop/index.html
+++ b/site/loops/strip-miner-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The Strip Miner loop</h1>
           <p class="detail-lede">An evidence-driven workflow-mining loop that finds repeated successes in authorized coding-agent history, rejects contradicted candidates, and validates extracted loops with fresh replay.</p>
           <p class="detail-byline">
-            Contributed by <strong>Alex Burkhart (@neuralwhisperer)</strong>
+            By <strong>Alex Burkhart (@neuralwhisperer)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/sub-50ms-page-load-loop/index.html
+++ b/site/loops/sub-50ms-page-load-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The sub-50 ms page-load loop</h1>
           <p class="detail-lede">A performance optimization workflow for coding agents that uses one repeatable benchmark and stops only when every target page meets the threshold.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/test-stabilizer-loop/index.html
+++ b/site/loops/test-stabilizer-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The test stabilizer loop</h1>
           <p class="detail-lede">A flaky-test repair workflow that measures inconsistent results, fixes one root cause at a time, and stops after a defined streak of stable full-suite runs.</p>
           <p class="detail-byline">
-            Contributed by <strong>hungtv27 (@hungtv27)</strong>
+            By <strong>hungtv27 (@hungtv27)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/test-suite-speed-loop/index.html
+++ b/site/loops/test-suite-speed-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The test-suite speed loop</h1>
           <p class="detail-lede">A performance workflow for reducing test runtime under repeatable conditions without weakening coverage, assertions, isolation, or behavior.</p>
           <p class="detail-byline">
-            Contributed by <strong>Matthew Berman</strong>
+            By <strong>Matthew Berman</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/ticket-to-pr-ready-loop/index.html
+++ b/site/loops/ticket-to-pr-ready-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The ticket-to-PR-ready loop</h1>
           <p class="detail-lede">A bounded engineering workflow that turns a ticket, failing behavior, or customer complaint into a proven root cause, minimal patch, and reviewer-ready handoff.</p>
           <p class="detail-byline">
-            Contributed by <strong>Hiten Shah</strong>
+            By <strong>Hiten Shah</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/ui-ux-score-loop/index.html
+++ b/site/loops/ui-ux-score-loop/index.html
@@ -211,7 +211,7 @@
           <h1>The UI/UX Score Loop</h1>
           <p class="detail-lede">A browser-based review that completes a real user task, scores each meaningful screen with the same checklist, improves weak spots, and retests the whole task.</p>
           <p class="detail-byline">
-            Contributed by <strong>Hayden Cassar (@hcassar93)</strong>
+            By <strong>Hayden Cassar (@hcassar93)</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/loops/war-loops-frontend-designer/index.html
+++ b/site/loops/war-loops-frontend-designer/index.html
@@ -211,7 +211,7 @@
           <h1>War Loops: frontend reconstruction</h1>
           <p class="detail-lede">A War Loops workflow that captures a real page, builds a static Pencil mirror and moving Forge version, then repairs the weakest fidelity signals.</p>
           <p class="detail-byline">
-            Contributed by <strong>Swayam</strong>
+            By <strong>Swayam</strong>
           </p>
           <div class="share-actions" aria-label="Share this loop">
             <button

--- a/site/styles.css
+++ b/site/styles.css
@@ -1267,16 +1267,13 @@ code {
 
 .detail-byline {
   margin-bottom: 0;
-  color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  color: var(--ink);
+  font-size: 0.95rem;
+  line-height: 1.5;
 }
 
 .detail-byline strong {
-  color: var(--ink);
+  font-weight: 700;
 }
 
 .detail-stack {


### PR DESCRIPTION
## Summary
- render a clear `By <author>` line on every loop detail page
- increase byline size and contrast so attribution is visibly readable
- keep generated pages and regression checks aligned

## Verification
- `node scripts/build-loop-pages.mjs`
- `node --check site/script.js`
- `node --check scripts/build-loop-pages.mjs`
- `node --check scripts/loop-data.mjs`
- `node scripts/check.mjs`
- `python3 -m json.tool site/.herenow/data.json >/dev/null`
- `git diff --check`
- browser verified rendered attribution at 15.2px