### PR TITLE
Bust cached detail page styles

### DIFF
--- a/scripts/build-loop-pages.mjs
+++ b/scripts/build-loop-pages.mjs
@@ -339,11 +339,11 @@ function renderLoopPage(loop) {
     <link rel="alternate" type="text/plain" title="${escapeHtml(site.name)} plain-text catalog" href="${escapeHtml(site.baseUrl)}catalog.txt" />
     <link rel="help" href="${escapeHtml(site.baseUrl)}agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 ${structuredData(loop)}
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>${escapeHtml(loop.seoTitle)}</title>
   </head>
   <body>

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -593,8 +593,8 @@ for (const [index, loop] of loops.entries()) {
     ),
   );
   assert(page.includes(`rel="help" href="${siteMeta.baseUrl}agents/"`));
-  assert(page.includes("../../styles.css?v=20260620-newest-first"));
-  assert(page.includes("../../script.js?v=20260620-newest-first"));
+  assert(page.includes("../../styles.css?v=20260621-author-byline"));
+  assert(page.includes("../../script.js?v=20260621-author-byline"));
   assert(page.includes(`<meta property="og:image" content="${imageUrl}"`));
   assert(page.includes(`<meta property="og:image:secure_url" content="${imageUrl}"`));
   assert(page.includes(`<meta property="og:image:type" content="${siteMeta.socialImageMimeType}"`));
@@ -869,8 +869,8 @@ assert(!html.includes('data-type='));
 assert(!html.includes('class="cell-type"'));
 assert(!html.includes("type-badge"));
 assert(!html.includes('<th scope="col">Type</th>'));
-assert(html.includes("./styles.css?v=20260620-newest-first"));
-assert(html.includes("./script.js?v=20260620-newest-first"));
+assert(html.includes("./styles.css?v=20260621-author-byline"));
+assert(html.includes("./script.js?v=20260621-author-byline"));
 assert(script.includes("const publishedDifference = b.dataset.published.localeCompare("));
 assert(script.includes("return loopRowPositions.get(b) - loopRowPositions.get(a);"));
 const homepagePostText =
@@ -933,8 +933,8 @@ assert.equal(
   (learnHtml.match(/href="https:\/\/here\.now\/r\/signals"/g) || []).length,
   2,
 );
-assert(learnHtml.includes("../styles.css?v=20260620-newest-first"));
-assert(learnHtml.includes("../script.js?v=20260620-newest-first"));
+assert(learnHtml.includes("../styles.css?v=20260621-author-byline"));
+assert(learnHtml.includes("../script.js?v=20260621-author-byline"));
 assert(learnHtml.includes("How agent loops work"));
 assert(learnHtml.includes('<meta name="robots" content="index, follow"'));
 assert(learnHtml.includes("What makes a loop useful"));
@@ -982,8 +982,8 @@ assert(agentHtml.includes("npx skills add Forward-Future/loop-library --skill lo
 assert(agentHtml.includes('<meta name="robots" content="index, follow"'));
 assert(agentHtml.includes(`href="${siteMeta.baseUrl}catalog.json"`));
 assert(agentHtml.includes(`href="${siteMeta.baseUrl}llms.txt"`));
-assert(agentHtml.includes("../styles.css?v=20260620-newest-first"));
-assert(agentHtml.includes("../script.js?v=20260620-newest-first"));
+assert(agentHtml.includes("../styles.css?v=20260621-author-byline"));
+assert(agentHtml.includes("../script.js?v=20260621-author-byline"));
 assert(html.includes("Repeatable AI Agent Workflows"));
 assert(html.includes('rel="sitemap"'));
 assert(html.includes(`href="${siteMeta.baseUrl}catalog.json"`));

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -76,8 +76,8 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260620-newest-first" />
-    <script src="../script.js?v=20260620-newest-first" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260621-author-byline" />
+    <script src="../script.js?v=20260621-author-byline" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="./styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -493,7 +493,7 @@
         ]
       }
     </script>
-    <script src="./script.js?v=20260620-newest-first" defer></script>
+    <script src="./script.js?v=20260621-author-byline" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -74,8 +74,8 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260620-newest-first" />
-    <script src="../script.js?v=20260620-newest-first" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260621-author-byline" />
+    <script src="../script.js?v=20260621-author-byline" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/loops/100-percent-test-coverage-loop/index.html
+++ b/site/loops/100-percent-test-coverage-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>100% Test Coverage Loop for Coding Agents | Loop Library</title>
   </head>
   <body>

--- a/site/loops/accessibility-repair-loop/index.html
+++ b/site/loops/accessibility-repair-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Accessibility Repair Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/architecture-satisfaction-loop/index.html
+++ b/site/loops/architecture-satisfaction-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Architecture Refactoring Loop for Coding Agents | Loop Library</title>
   </head>
   <body>

--- a/site/loops/artifact-to-skill-loop/index.html
+++ b/site/loops/artifact-to-skill-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Artifact-to-Skill Extraction Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/autonomy-loop/index.html
+++ b/site/loops/autonomy-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>autonomy-loop Builder-Reviewer Workflow | Loop Library</title>
   </head>
   <body>

--- a/site/loops/axelrod-subagent-arena-loop/index.html
+++ b/site/loops/axelrod-subagent-arena-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Axelrod Subagent Arena Benchmark | Loop Library</title>
   </head>
   <body>

--- a/site/loops/boeing-747-benchmark/index.html
+++ b/site/loops/boeing-747-benchmark/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Boeing 747 Three.js Vision Benchmark | Loop Library</title>
   </head>
   <body>

--- a/site/loops/clodex-adversarial-review-loop/index.html
+++ b/site/loops/clodex-adversarial-review-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Clodex Adversarial Code Review Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/codex-completion-contract-loop/index.html
+++ b/site/loops/codex-completion-contract-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Codex Completion Contract and Evidence Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/cold-load-trimmer-loop/index.html
+++ b/site/loops/cold-load-trimmer-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Cold-Load Byte Reduction Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/customer-ai-deployment-loop/index.html
+++ b/site/loops/customer-ai-deployment-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Customer AI Deployment Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/devils-advocate-design-loop/index.html
+++ b/site/loops/devils-advocate-design-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Devil&#39;s-Advocate Design Review Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/easy-onboarding-loop/index.html
+++ b/site/loops/easy-onboarding-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Fresh-State Onboarding Improvement Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/exhaustive-logging-coverage-loop/index.html
+++ b/site/loops/exhaustive-logging-coverage-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Logging Coverage Loop for Coding Agents | Loop Library</title>
   </head>
   <body>

--- a/site/loops/five-minute-repository-maintainer-loop/index.html
+++ b/site/loops/five-minute-repository-maintainer-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Five-Minute Repository Maintainer Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/fresh-clone-loop/index.html
+++ b/site/loops/fresh-clone-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Fresh Clone README Verification Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/full-product-evaluation-loop/index.html
+++ b/site/loops/full-product-evaluation-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Full Product Evaluation Loop for AI Systems | Loop Library</title>
   </head>
   <body>

--- a/site/loops/goal-forge-loop/index.html
+++ b/site/loops/goal-forge-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Goal Forge Specification Loop for Codex | Loop Library</title>
   </head>
   <body>

--- a/site/loops/groundtruth-audit-loop/index.html
+++ b/site/loops/groundtruth-audit-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Groundtruth Evidence-Based Project Audit | Loop Library</title>
   </head>
   <body>

--- a/site/loops/housekeeper-loop/index.html
+++ b/site/loops/housekeeper-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Repository Housekeeper Cleanup Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/infinite-clickbait-loop/index.html
+++ b/site/loops/infinite-clickbait-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Infinite Clickbait Thumbnail Iteration Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/living-story-loop/index.html
+++ b/site/loops/living-story-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Living Story Project Context Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/loop-harness-verification-loop/index.html
+++ b/site/loops/loop-harness-verification-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Loop Harness Second-Agent Verification Workflow | Loop Library</title>
   </head>
   <body>

--- a/site/loops/multi-llm-convergence-loop/index.html
+++ b/site/loops/multi-llm-convergence-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Multi-LLM Convergence Review Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/nightly-changelog-sweep/index.html
+++ b/site/loops/nightly-changelog-sweep/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Nightly Changelog Loop for Coding Agents | Loop Library</title>
   </head>
   <body>

--- a/site/loops/overnight-docs-sweep/index.html
+++ b/site/loops/overnight-docs-sweep/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Documentation Sweep for Coding Agents | Loop Library</title>
   </head>
   <body>

--- a/site/loops/pixel-safe-css-trim-loop/index.html
+++ b/site/loops/pixel-safe-css-trim-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Pixel-Safe CSS Reduction Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/post-release-baseline-loop/index.html
+++ b/site/loops/post-release-baseline-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Post-Release Benchmark Baseline Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/prepare-new-project-loop/index.html
+++ b/site/loops/prepare-new-project-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Prepare a New Project Documentation Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/product-update-podcast-loop/index.html
+++ b/site/loops/product-update-podcast-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Product Update Podcast Automation Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/production-data-cleanup-loop/index.html
+++ b/site/loops/production-data-cleanup-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Production Data Cleanup Loop for AI Systems | Loop Library</title>
   </head>
   <body>

--- a/site/loops/production-error-sweep/index.html
+++ b/site/loops/production-error-sweep/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Production Error Triage Loop for Coding Agents | Loop Library</title>
   </head>
   <body>

--- a/site/loops/promise-to-proof-loop/index.html
+++ b/site/loops/promise-to-proof-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Promise-to-Proof Product Audit | Loop Library</title>
   </head>
   <body>

--- a/site/loops/propagation-compliance-loop/index.html
+++ b/site/loops/propagation-compliance-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Repository Propagation Compliance Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/quality-streak-loop/index.html
+++ b/site/loops/quality-streak-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Quality Streak Evaluation Loop for AI Products | Loop Library</title>
   </head>
   <body>

--- a/site/loops/recent-feedback-sweep/index.html
+++ b/site/loops/recent-feedback-sweep/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Recent-Feedback Project Audit | Loop Library</title>
   </head>
   <body>

--- a/site/loops/recovery-proof-loop/index.html
+++ b/site/loops/recovery-proof-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Backup Recovery Proof Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/repository-cleanup-loop/index.html
+++ b/site/loops/repository-cleanup-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Repository Cleanup Loop for Coding Agents | Loop Library</title>
   </head>
   <body>

--- a/site/loops/revolve-self-improvement-loop/index.html
+++ b/site/loops/revolve-self-improvement-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Revolve Versioned Experiment Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/self-improving-champion-loop/index.html
+++ b/site/loops/self-improving-champion-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Self-Improving Champion Evaluation Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/seo-geo-visibility-loop/index.html
+++ b/site/loops/seo-geo-visibility-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>SEO and GEO Visibility Audit Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/stale-safe-batch-release-loop/index.html
+++ b/site/loops/stale-safe-batch-release-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Stale-Safe Batch Release Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/strip-miner-loop/index.html
+++ b/site/loops/strip-miner-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Strip Miner Workflow Discovery Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/sub-50ms-page-load-loop/index.html
+++ b/site/loops/sub-50ms-page-load-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Sub-50 ms Page-Load Optimization Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/test-stabilizer-loop/index.html
+++ b/site/loops/test-stabilizer-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Flaky Test Stabilizer Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/test-suite-speed-loop/index.html
+++ b/site/loops/test-suite-speed-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Test-Suite Speed Optimization Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/ticket-to-pr-ready-loop/index.html
+++ b/site/loops/ticket-to-pr-ready-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Ticket-to-PR-Ready Loop for Coding Agents | Loop Library</title>
   </head>
   <body>

--- a/site/loops/ui-ux-score-loop/index.html
+++ b/site/loops/ui-ux-score-loop/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>Browser UI/UX Score Loop | Loop Library</title>
   </head>
   <body>

--- a/site/loops/war-loops-frontend-designer/index.html
+++ b/site/loops/war-loops-frontend-designer/index.html
@@ -60,7 +60,7 @@
     <link rel="alternate" type="text/plain" title="Loop Library plain-text catalog" href="https://signals.forwardfuture.ai/loop-library/catalog.txt" />
     <link rel="help" href="https://signals.forwardfuture.ai/loop-library/agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260620-newest-first" />
+    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -132,7 +132,7 @@
   ]
 }
     </script>
-    <script src="../../script.js?v=20260620-newest-first" defer></script>
+    <script src="../../script.js?v=20260621-author-byline" defer></script>
     <title>War Loops Frontend Reconstruction Workflow | Loop Library</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- bump the shared asset version so browsers load the readable author byline styles
- update all generated loop pages and static entry points
- keep cache-version regression checks aligned

## Verification
- full repository checks pass
- production diagnosis confirmed HTML was current while the browser retained the old stylesheet under the unchanged asset URL