### PR TITLE
[codex] Remove agent guide promo link

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -916,6 +916,11 @@ assert(
 assert(html.includes("Use Loop Library in your coding agent."));
 assert(html.includes('href="./agents/"'));
 assert(html.includes("Send an agent to the live guide"));
+const skillPromoHtml = html.slice(
+  html.indexOf('id="agent-skill"'),
+  html.indexOf("</section>", html.indexOf('id="agent-skill"')),
+);
+assert(!skillPromoHtml.includes("Agent guide"));
 assert(
   html.includes(
     "npx skills add Forward-Future/loop-library --skill loop-library",

--- a/site/index.html
+++ b/site/index.html
@@ -618,9 +618,6 @@
               -g</code
             >
             <div class="skill-action-row">
-              <a class="skill-github-link" href="./agents/">
-                Agent guide
-              </a>
               <button
                 class="skill-copy-button"
                 type="button"


### PR DESCRIPTION
## What changed

- remove the Agent guide link from the homepage agent-skill promo
- keep the Copy command and View repository actions unchanged
- add a regression assertion for the promo

## Why

The promo should present only the install action and repository link in this location.

## Validation

- `node --check site/script.js`
- `node scripts/check.mjs`
- `python3 -m json.tool site/.herenow/data.json`
- `git diff --check`
- rendered local browser verification