### PR TITLE
[codex] Link nav to the GitHub skill

### DIFF
--- a/scripts/build-loop-pages.mjs
+++ b/scripts/build-loop-pages.mjs
@@ -366,6 +366,14 @@ ${structuredData(loop)}
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -390,6 +398,14 @@ ${structuredData(loop)}
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -693,6 +693,10 @@ for (const [index, loop] of loops.entries()) {
   );
   assert(page.includes('<a href="../../learn/">Learn</a>'));
   assert(page.includes('<a href="../../agents/">For agents</a>'));
+  assert.equal(
+    (page.match(/aria-label="Loop Library skill on GitHub"/g) || []).length,
+    2,
+  );
   assert.equal((page.match(/class="mobile-site-nav"/g) || []).length, 1);
   assert(!page.includes('href="../../#tips"'));
   assert(page.includes('data-copy-root'));
@@ -896,6 +900,10 @@ assert(!html.includes(`<span>Copy link</span>`));
 assert(html.includes('<a href="#library" aria-current="page">Loops</a>'));
 assert(html.includes('<a href="./learn/">Learn</a>'));
 assert(html.includes('<a href="./agents/">For agents</a>'));
+assert.equal(
+  (html.match(/aria-label="Loop Library skill on GitHub"/g) || []).length,
+  2,
+);
 assert.equal((html.match(/class="mobile-site-nav"/g) || []).length, 1);
 assert(!html.includes('class="loop-guide"'));
 assert(!html.includes("A useful loop specifies:"));
@@ -933,7 +941,7 @@ assert(
 );
 assert(html.includes("<span>Copy command</span>"));
 assert(
-  !html.includes(
+  html.includes(
     "https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library",
   ),
 );
@@ -972,6 +980,10 @@ assert(learnHtml.includes('id="devin"'));
 assert(learnHtml.includes('href="../agents/">For agents</a>'));
 assert(learnHtml.includes('<a href="../#library">Loops</a>'));
 assert(learnHtml.includes('<a href="./" aria-current="page">Learn</a>'));
+assert.equal(
+  (learnHtml.match(/aria-label="Loop Library skill on GitHub"/g) || []).length,
+  2,
+);
 assert.equal((learnHtml.match(/class="mobile-site-nav"/g) || []).length, 1);
 assert(learnHtml.includes(`href="${siteMeta.baseUrl}llms.txt"`));
 assert(learnHtml.includes(`href="${siteMeta.baseUrl}agents/"`));
@@ -984,6 +996,10 @@ assert(agentHtml.includes("Use Loop Library directly."));
 assert(agentHtml.includes('<a href="../#library">Loops</a>'));
 assert(agentHtml.includes('<a href="../learn/">Learn</a>'));
 assert(agentHtml.includes('<a href="./" aria-current="page">For agents</a>'));
+assert.equal(
+  (agentHtml.match(/aria-label="Loop Library skill on GitHub"/g) || []).length,
+  2,
+);
 assert.equal((agentHtml.match(/class="mobile-site-nav"/g) || []).length, 1);
 assert(agentHtml.includes("No skill installation is required."));
 assert(agentHtml.includes('href="../catalog.json"'));

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -114,6 +114,14 @@
         <a href="../#library">Loops</a>
         <a href="../learn/">Learn</a>
         <a href="./" aria-current="page">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -156,6 +164,14 @@
         <a href="../#library">Loops</a>
         <a href="../learn/">Learn</a>
         <a href="./" aria-current="page">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/index.html
+++ b/site/index.html
@@ -522,6 +522,14 @@
         <a href="#library" aria-current="page">Loops</a>
         <a href="./learn/">Learn</a>
         <a href="./agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -564,6 +572,14 @@
         <a href="#library" aria-current="page">Loops</a>
         <a href="./learn/">Learn</a>
         <a href="./agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -112,6 +112,14 @@
         <a href="../#library">Loops</a>
         <a href="./" aria-current="page">Learn</a>
         <a href="../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -154,6 +162,14 @@
         <a href="../#library">Loops</a>
         <a href="./" aria-current="page">Learn</a>
         <a href="../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/100-percent-test-coverage-loop/index.html
+++ b/site/loops/100-percent-test-coverage-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/accessibility-repair-loop/index.html
+++ b/site/loops/accessibility-repair-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/architecture-satisfaction-loop/index.html
+++ b/site/loops/architecture-satisfaction-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/artifact-to-skill-loop/index.html
+++ b/site/loops/artifact-to-skill-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/autonomy-loop/index.html
+++ b/site/loops/autonomy-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/axelrod-subagent-arena-loop/index.html
+++ b/site/loops/axelrod-subagent-arena-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/boeing-747-benchmark/index.html
+++ b/site/loops/boeing-747-benchmark/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/clodex-adversarial-review-loop/index.html
+++ b/site/loops/clodex-adversarial-review-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/codex-completion-contract-loop/index.html
+++ b/site/loops/codex-completion-contract-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/cold-load-trimmer-loop/index.html
+++ b/site/loops/cold-load-trimmer-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/customer-ai-deployment-loop/index.html
+++ b/site/loops/customer-ai-deployment-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/devils-advocate-design-loop/index.html
+++ b/site/loops/devils-advocate-design-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/easy-onboarding-loop/index.html
+++ b/site/loops/easy-onboarding-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/exhaustive-logging-coverage-loop/index.html
+++ b/site/loops/exhaustive-logging-coverage-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/five-minute-repository-maintainer-loop/index.html
+++ b/site/loops/five-minute-repository-maintainer-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/fresh-clone-loop/index.html
+++ b/site/loops/fresh-clone-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/full-product-evaluation-loop/index.html
+++ b/site/loops/full-product-evaluation-loop/index.html
@@ -158,6 +158,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -200,6 +208,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/goal-forge-loop/index.html
+++ b/site/loops/goal-forge-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/groundtruth-audit-loop/index.html
+++ b/site/loops/groundtruth-audit-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/housekeeper-loop/index.html
+++ b/site/loops/housekeeper-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/infinite-clickbait-loop/index.html
+++ b/site/loops/infinite-clickbait-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/living-story-loop/index.html
+++ b/site/loops/living-story-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/loop-harness-verification-loop/index.html
+++ b/site/loops/loop-harness-verification-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/multi-llm-convergence-loop/index.html
+++ b/site/loops/multi-llm-convergence-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/nightly-changelog-sweep/index.html
+++ b/site/loops/nightly-changelog-sweep/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/overnight-docs-sweep/index.html
+++ b/site/loops/overnight-docs-sweep/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/pixel-safe-css-trim-loop/index.html
+++ b/site/loops/pixel-safe-css-trim-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/post-release-baseline-loop/index.html
+++ b/site/loops/post-release-baseline-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/prepare-new-project-loop/index.html
+++ b/site/loops/prepare-new-project-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/product-update-podcast-loop/index.html
+++ b/site/loops/product-update-podcast-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/production-data-cleanup-loop/index.html
+++ b/site/loops/production-data-cleanup-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/production-error-sweep/index.html
+++ b/site/loops/production-error-sweep/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/promise-to-proof-loop/index.html
+++ b/site/loops/promise-to-proof-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/propagation-compliance-loop/index.html
+++ b/site/loops/propagation-compliance-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/quality-streak-loop/index.html
+++ b/site/loops/quality-streak-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/recent-feedback-sweep/index.html
+++ b/site/loops/recent-feedback-sweep/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/recovery-proof-loop/index.html
+++ b/site/loops/recovery-proof-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/refund-follow-up-loop/index.html
+++ b/site/loops/refund-follow-up-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/repository-cleanup-loop/index.html
+++ b/site/loops/repository-cleanup-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/revolve-self-improvement-loop/index.html
+++ b/site/loops/revolve-self-improvement-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/self-improving-champion-loop/index.html
+++ b/site/loops/self-improving-champion-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/seo-geo-visibility-loop/index.html
+++ b/site/loops/seo-geo-visibility-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/stale-safe-batch-release-loop/index.html
+++ b/site/loops/stale-safe-batch-release-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/strip-miner-loop/index.html
+++ b/site/loops/strip-miner-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/sub-50ms-page-load-loop/index.html
+++ b/site/loops/sub-50ms-page-load-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/test-stabilizer-loop/index.html
+++ b/site/loops/test-stabilizer-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/test-suite-speed-loop/index.html
+++ b/site/loops/test-suite-speed-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/ticket-to-pr-ready-loop/index.html
+++ b/site/loops/ticket-to-pr-ready-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/ui-ux-score-loop/index.html
+++ b/site/loops/ui-ux-score-loop/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 

--- a/site/loops/war-loops-frontend-designer/index.html
+++ b/site/loops/war-loops-frontend-designer/index.html
@@ -155,6 +155,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
         <button
           class="theme-toggle"
           id="theme-toggle"
@@ -197,6 +205,14 @@
         <a href="../../#library" aria-current="page">Loops</a>
         <a href="../../learn/">Learn</a>
         <a href="../../agents/">For agents</a>
+        <a
+          href="https://github.com/Forward-Future/loop-library/tree/main/skills/loop-library"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Loop Library skill on GitHub"
+        >
+          Skill
+        </a>
       </nav>
     </header>
 


### PR DESCRIPTION
## Summary
- add a Skill item to the desktop and mobile primary navigation
- link directly to the installable Loop Library skill directory on GitHub
- propagate the shared navigation link to every generated loop detail page

## Why
The primary navigation exposed Loops, Learn, and For agents, but did not offer a direct path to the repository's installable skill.

## Validation
- full repository validation passed
- Worker tests: 15/15
- browser-verified at 1280px and 795px
- GitHub destination resolved successfully