### PR TITLE
Center here.now credit in navigation

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -119,6 +119,17 @@ for (const value of [
   assert(html.includes(value), value);
 }
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
+for (const page of [html, learnHtml, agentHtml]) {
+  const brandPosition = page.indexOf('class="brand-lockup"');
+  const creditPosition = page.indexOf(
+    'class="here-now-credit here-now-credit--header"',
+  );
+  const navPosition = page.indexOf('class="site-nav"');
+  assert(brandPosition < creditPosition && creditPosition < navPosition);
+}
+assert(
+  css.includes("grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);"),
+);
 assert(learnHtml.includes("How agent loops work"));
 assert(agentHtml.includes("For AI agents"));
 assert(css.includes(".loop-row"));

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -110,6 +110,26 @@
         <span class="brand-product">Loop Library</span>
       </a>
 
+      <a
+        class="here-now-credit here-now-credit--header"
+        data-here-now-credit
+        href="https://here.now/r/signals"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Hosted by here.now"
+      >
+        <img
+          class="here-now-credit__icon"
+          src="../assets/here-now-icon.svg"
+          alt=""
+          aria-hidden="true"
+        />
+        <span class="here-now-credit__text">
+          <small>Hosted by</small>
+          <strong>here.now</strong>
+        </span>
+      </a>
+
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../#library">Loops</a>
         <a href="../learn/">Learn</a>
@@ -140,25 +160,6 @@
           <span class="theme-label theme-label-dark">Dark</span>
         </button>
         <a class="nav-cta" href="../#submit">Submit a loop</a>
-        <a
-          class="here-now-credit here-now-credit--header"
-          data-here-now-credit
-          href="https://here.now/r/signals"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Hosted by here.now"
-        >
-          <img
-            class="here-now-credit__icon"
-            src="../assets/here-now-icon.svg"
-            alt=""
-            aria-hidden="true"
-          />
-          <span class="here-now-credit__text">
-            <small>Hosted by</small>
-            <strong>here.now</strong>
-          </span>
-        </a>
       </nav>
       <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
         <a href="../#library">Loops</a>

--- a/site/index.html
+++ b/site/index.html
@@ -217,6 +217,26 @@
         <span class="brand-product">Loop Library</span>
       </a>
 
+      <a
+        class="here-now-credit here-now-credit--header"
+        data-here-now-credit
+        href="https://here.now/r/signals"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Hosted by here.now"
+      >
+        <img
+          class="here-now-credit__icon"
+          src="./assets/here-now-icon.svg"
+          alt=""
+          aria-hidden="true"
+        />
+        <span class="here-now-credit__text">
+          <small>Hosted by</small>
+          <strong>here.now</strong>
+        </span>
+      </a>
+
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="#library" aria-current="page">Loops</a>
         <a href="./learn/">Learn</a>
@@ -247,25 +267,6 @@
           <span class="theme-label theme-label-dark">Dark</span>
         </button>
         <a class="nav-cta" href="#submit">Submit a loop</a>
-        <a
-          class="here-now-credit here-now-credit--header"
-          data-here-now-credit
-          href="https://here.now/r/signals"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Hosted by here.now"
-        >
-          <img
-            class="here-now-credit__icon"
-            src="./assets/here-now-icon.svg"
-            alt=""
-            aria-hidden="true"
-          />
-          <span class="here-now-credit__text">
-            <small>Hosted by</small>
-            <strong>here.now</strong>
-          </span>
-        </a>
       </nav>
       <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">
         <a href="#library" aria-current="page">Loops</a>

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -108,6 +108,26 @@
         <span class="brand-product">Loop Library</span>
       </a>
 
+      <a
+        class="here-now-credit here-now-credit--header"
+        data-here-now-credit
+        href="https://here.now/r/signals"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Hosted by here.now"
+      >
+        <img
+          class="here-now-credit__icon"
+          src="../assets/here-now-icon.svg"
+          alt=""
+          aria-hidden="true"
+        />
+        <span class="here-now-credit__text">
+          <small>Hosted by</small>
+          <strong>here.now</strong>
+        </span>
+      </a>
+
       <nav class="site-nav" aria-label="Primary navigation">
         <a href="../#library">Loops</a>
         <a href="./" aria-current="page">Learn</a>
@@ -137,25 +157,6 @@
           <span class="theme-label theme-label-light">Light</span>
           <span class="theme-label theme-label-dark">Dark</span>
         </button>
-        <a
-          class="here-now-credit here-now-credit--header"
-          data-here-now-credit
-          href="https://here.now/r/signals"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Hosted by here.now"
-        >
-          <img
-            class="here-now-credit__icon"
-            src="../assets/here-now-icon.svg"
-            alt=""
-            aria-hidden="true"
-          />
-          <span class="here-now-credit__text">
-            <small>Hosted by</small>
-            <strong>here.now</strong>
-          </span>
-        </a>
         <a class="nav-cta" href="../#submit">Submit a loop</a>
       </nav>
       <nav class="mobile-site-nav" aria-label="Primary navigation on small screens">

--- a/site/styles.css
+++ b/site/styles.css
@@ -141,10 +141,10 @@ code {
   position: sticky;
   z-index: 20;
   top: 0;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   min-height: 64px;
   align-items: center;
-  justify-content: space-between;
   gap: 24px;
   padding: 0 var(--page-pad);
   border-bottom: 1px solid var(--ink);
@@ -154,6 +154,7 @@ code {
 
 .brand-lockup {
   display: flex;
+  justify-self: start;
   align-items: center;
   gap: 10px;
   text-decoration: none;
@@ -180,10 +181,12 @@ code {
 
 .site-nav {
   display: flex;
+  justify-self: end;
   align-items: center;
-  gap: clamp(16px, 2.5vw, 32px);
+  gap: clamp(12px, 1.6vw, 24px);
   font-size: 0.86rem;
   font-weight: 700;
+  white-space: nowrap;
 }
 
 .site-nav a {
@@ -331,6 +334,10 @@ code {
 
 .here-now-credit--footer {
   color: var(--light);
+}
+
+.here-now-credit--header {
+  justify-self: center;
 }
 
 .here-now-credit--footer .here-now-credit__icon {
@@ -1881,19 +1888,18 @@ code {
   }
 
   .site-header {
-    flex-wrap: wrap;
     padding-top: 8px;
     row-gap: 0;
   }
 
-  .site-nav > a:not(.nav-cta):not(.here-now-credit) {
+  .site-nav > a:not(.nav-cta) {
     display: none;
   }
 
   .mobile-site-nav {
     display: flex;
+    grid-column: 1 / -1;
     width: 100%;
-    flex: 0 0 100%;
     align-items: center;
     justify-content: center;
     gap: clamp(28px, 8vw, 64px);
@@ -2111,6 +2117,25 @@ code {
 }
 
 @media (max-width: 620px) {
+  .site-header {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .here-now-credit--header {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    padding-top: 6px;
+  }
+
+  .site-nav {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .mobile-site-nav {
+    grid-row: 3;
+  }
+
   .brand-name {
     display: none;
   }


### PR DESCRIPTION
## Summary\n- center the here.now hosting credit in the shared desktop header\n- give the credit a dedicated centered row on narrow screens\n- apply the shared layout to the homepage, Learn, and For agents pages\n- add regression coverage for the header placement\n\n## Verification\n- node --check site/script.js\n- node scripts/check.mjs\n- npm --prefix worker run check\n- python3 -m json.tool site/.herenow/data.json\n- python3 -m json.tool scripts/seo-geo-query-benchmark.json\n- here.now branding validator\n- desktop and 390px browser checks