### PR TITLE
[codex] Make loop search more prominent

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -118,9 +118,18 @@ for (const value of [
 ]) {
   assert(html.includes(value), value);
 }
+assert(html.includes("Search the library"));
+assert(html.includes("Search by title, task, or contributor"));
+assert(html.includes('class="search-field"'));
+assert(html.includes("styles.css?v=20260622-search-prominence"));
+assert(css.includes(".search-control-label"));
+assert(css.includes(".search-control:hover .search-field"));
+assert(css.includes(".search-control:focus-within .search-field"));
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
-for (const page of [html, learnHtml, agentHtml]) {
+for (const page of [learnHtml, agentHtml]) {
   assert(page.includes("styles.css?v=20260622-centered-host-credit"));
+}
+for (const page of [html, learnHtml, agentHtml]) {
   const brandPosition = page.indexOf('class="brand-lockup"');
   const creditPosition = page.indexOf(
     'class="here-now-credit here-now-credit--header"',

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260622-centered-host-credit" />
+    <link rel="stylesheet" href="./styles.css?v=20260622-search-prominence" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -355,17 +355,19 @@
 
         <div class="library-controls">
           <label class="search-control">
-            <span class="sr-only">Search loops</span>
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="11" cy="11" r="7"></circle>
-              <path d="m20 20-4-4"></path>
-            </svg>
-            <input
-              id="loop-search"
-              type="search"
-              placeholder="Search loops or contributors"
-              autocomplete="off"
-            />
+            <span class="search-control-label">Search the library</span>
+            <span class="search-field">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="11" cy="11" r="7"></circle>
+                <path d="m20 20-4-4"></path>
+              </svg>
+              <input
+                id="loop-search"
+                type="search"
+                placeholder="Search by title, task, or contributor"
+                autocomplete="off"
+              />
+            </span>
           </label>
 
           <div class="library-refinements">

--- a/site/styles.css
+++ b/site/styles.css
@@ -610,47 +610,81 @@ code {
   flex-direction: column;
   gap: 14px;
   margin-top: 32px;
-  padding: 12px 0;
+  padding: 16px 0;
   border-top: 1px solid var(--ink);
   border-bottom: 1px solid var(--ink);
 }
 
 .search-control {
-  display: flex;
+  display: block;
   width: min(100%, 680px);
+  cursor: text;
+}
+
+.search-control-label {
+  display: block;
+  width: max-content;
+  padding: 5px 9px;
+  color: var(--charcoal);
+  background: var(--orange);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.search-field {
+  display: flex;
+  min-height: 52px;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
+  padding: 0 14px;
+  border: 2px solid var(--ink);
+  background: var(--surface);
 }
 
 .search-control:focus-within {
   color: var(--orange);
 }
 
-.search-control svg {
-  width: 18px;
-  height: 18px;
+.search-control:hover .search-field {
+  border-color: var(--orange);
+}
+
+.search-control:focus-within .search-field {
+  outline: 3px solid var(--orange);
+  outline-offset: 3px;
+}
+
+.search-field svg {
+  width: 22px;
+  height: 22px;
   flex: 0 0 auto;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.8;
+  stroke-width: 2;
 }
 
-.search-control input {
+.search-field input {
   width: 100%;
-  padding: 8px 0 6px;
+  padding: 13px 0;
   border: 0;
   border-bottom: 2px solid transparent;
   outline: 0;
   color: var(--ink);
   background: transparent;
+  font-weight: 650;
 }
 
 .search-control input:focus-visible {
   border-bottom-color: currentColor;
 }
 
-.search-control input::placeholder {
+.search-field input::placeholder {
   color: var(--placeholder);
+  font-weight: 500;
 }
 
 .category-filters {


### PR DESCRIPTION
## What changed
- adds a visible high-contrast “Search the library” label
- gives the search input a bordered 52px field, larger icon, and clearer prompt
- adds hover/focus treatments and keeps the control responsive
- cache-busts the homepage stylesheet and adds regression assertions

## Why
The previous transparent, unlabeled search treatment blended into the surrounding controls and was easy to overlook.

## Validation
- `node --check site/script.js`
- `node scripts/check.mjs`
- `npm --prefix worker run check` (41 tests)
- JSON validation for here.now data/proxy and SEO benchmark files
- `git diff --check`
- rendered desktop and 390px mobile browser verification