### PR TITLE
[codex] Add GitHub-authenticated loop voting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,30 @@ npm run deploy
 `TURNSTILE_HOSTNAMES` is a comma-separated exact allowlist containing
 `signals.forwardfuture.ai` and the current backing `*.here.now` hostname.
 
+## Authenticated voting
+
+- Public vote totals live in the `VOTE_STORE` SQLite Durable Object. A GitHub
+  account may hold at most one vote per loop and can switch or remove it.
+- Vote writes require a valid HMAC-signed, HTTP-only session cookie plus an
+  exact trusted `Origin`. Never accept provider IDs, usernames, or voter keys
+  from browser JSON.
+- Keep OAuth state in short-lived, signed, HTTP-only cookies. Keep post-login
+  redirects on the canonical Loop Library path.
+- Do not expose OAuth client secrets or `SESSION_SECRET` in Worker variables,
+  browser code, logs, or committed development files. Configure them with:
+
+  ```bash
+  cd worker
+  npm exec -- wrangler secret put SESSION_SECRET
+  npm exec -- wrangler secret put GITHUB_OAUTH_CLIENT_ID
+  npm exec -- wrangler secret put GITHUB_OAUTH_CLIENT_SECRET
+  ```
+
+- Register this exact provider callback:
+  `https://signals.forwardfuture.ai/loop-library/auth/callback/github`.
+- Deploy and verify the Worker before publishing a shell or proxy manifest that
+  exposes voting or auth routes.
+
 For local development, copy `worker/.dev.vars.example` to `worker/.dev.vars`,
 replace the here.now development credentials, then run:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,15 @@ npm run deploy
 
 - Register this exact provider callback:
   `https://signals.forwardfuture.ai/loop-library/auth/callback/github`.
+- Keep `VOTING_UI_ENABLED` set to the exact string `false` for the first
+  production release. Vote controls render hidden and disabled, then appear
+  only when `/api/votes` returns `uiEnabled: true`; missing or malformed values
+  must remain fail-closed.
+- With the launch flag off, verify the canonical GitHub start, callback,
+  session, vote persistence, reload, and logout flow. Change the flag to the
+  exact string `true` and redeploy the Worker from newest integrated `main`
+  only after that smoke test passes. No site republish is required to reveal
+  the controls.
 - Deploy and verify the Worker before publishing a shell or proxy manifest that
   exposes voting or auth routes.
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,15 @@ python3 -m json.tool scripts/seo-geo-query-benchmark.json >/dev/null
 git diff --check
 ```
 
+### Configure voting
+
+Voting is stored in a dedicated SQLite Durable Object. Reading totals is
+public, but casting, changing, or removing a vote requires a GitHub login.
+Set `SESSION_SECRET` and the GitHub OAuth client credentials as Worker
+secrets; use `worker/.dev.vars.example` for local variable names only. Register
+the canonical callbacks shown in `AGENTS.md`, then deploy the Worker before the
+site shell because the shell calls the new auth and vote routes.
+
 Read [AGENTS.md](AGENTS.md) before editing loops or publishing the site. It
 contains the source-of-truth rules for database publishing, generated
 responses, form security, and clean-main deployments.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ secrets; use `worker/.dev.vars.example` for local variable names only. Register
 the canonical callbacks shown in `AGENTS.md`, then deploy the Worker before the
 site shell because the shell calls the new auth and vote routes.
 
+The production launch is fail-closed. Keep `VOTING_UI_ENABLED=false` while the
+Worker and proxy are deployed, then complete a GitHub login, session, vote,
+reload, and logout smoke test on the canonical domain. Set the value to the
+exact string `true` and redeploy only the Worker after the smoke test passes;
+the already-published site will reveal voting without another site publish.
+
 Read [AGENTS.md](AGENTS.md) before editing loops or publishing the site. It
 contains the source-of-truth rules for database publishing, generated
 responses, form security, and clean-main deployments.

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -19,6 +19,8 @@ const [
   workerSource,
   loopRoutesSource,
   catalogStoreSource,
+  authVotesSource,
+  voteStoreSource,
   rendererSource,
   workerPackageSource,
   workerLockSource,
@@ -39,6 +41,8 @@ const [
   readFile(path.join(workerRoot, "src", "index.js"), "utf8"),
   readFile(path.join(workerRoot, "src", "loop-routes.js"), "utf8"),
   readFile(path.join(workerRoot, "src", "catalog-store.js"), "utf8"),
+  readFile(path.join(workerRoot, "src", "auth-votes.js"), "utf8"),
+  readFile(path.join(workerRoot, "src", "vote-store.js"), "utf8"),
   readFile(path.join(workerRoot, "src", "render-loops.js"), "utf8"),
   readFile(path.join(workerRoot, "package.json"), "utf8"),
   readFile(path.join(workerRoot, "package-lock.json"), "utf8"),
@@ -121,14 +125,15 @@ for (const value of [
 assert(html.includes("Search the library"));
 assert(html.includes("Search by title, task, or contributor"));
 assert(html.includes('class="search-field"'));
-assert(html.includes("styles.css?v=20260622-sort-focus"));
-assert(html.includes("script.js?v=20260622-sort-focus"));
+assert(html.includes("styles.css?v=20260623-popular-ranking"));
+assert(html.includes("script.js?v=20260623-popular-ranking"));
 assert(css.includes(".search-control-label"));
 assert(css.includes(".search-control:hover .search-field"));
 assert(css.includes(".search-control:focus-within .search-field"));
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
 for (const page of [learnHtml, agentHtml]) {
-  assert(page.includes("styles.css?v=20260622-centered-host-credit"));
+  assert(page.includes("styles.css?v=20260623-popular-ranking"));
+  assert(page.includes("script.js?v=20260623-popular-ranking"));
 }
 for (const page of [html, learnHtml, agentHtml]) {
   const brandPosition = page.indexOf('class="brand-lockup"');
@@ -155,6 +160,9 @@ assert(html.includes('<option value="oldest">Oldest → newest</option>'));
 assert(browserScript.includes('"oldest"'));
 assert(browserScript.includes('sortSelect.addEventListener("change"'));
 assert(browserScript.includes('params.set("sort", activeSort)'));
+assert(browserScript.includes("function comparePopular"));
+assert(browserScript.includes("Number(b.dataset.upvotes || 0)"));
+assert(html.includes('<option value="featured">Featured, then popular</option>'));
 assert(browserScript.includes("library-pagination"));
 assert(!browserScript.includes("innerHTML"));
 
@@ -172,6 +180,20 @@ for (const collectionConfig of [suggestions, weeklySignups]) {
 assert(workerSource.includes("TURNSTILE_RATE_LIMITER.limit"));
 assert(workerSource.includes("https://challenges.cloudflare.com/turnstile/v0/siteverify"));
 assert(workerSource.includes("handleLoopRoute"));
+assert(workerSource.includes("handleAuthVoteRoute"));
+assert(browserScript.includes('document.querySelectorAll("[data-vote-controls]")'));
+assert(browserScript.includes('credentials: "same-origin"'));
+assert(css.includes(".vote-controls"));
+assert(css.includes(".login-dialog"));
+assert(rendererSource.includes("renderVoteControls(loop.slug)"));
+assert(rendererSource.includes('class="vote-label"'));
+assert(authVotesSource.includes('scope: "read:user"'));
+assert(!authVotesSource.includes("X_OAUTH"));
+assert(!authVotesSource.includes('"/auth/x"'));
+assert(!browserScript.includes("Continue with X"));
+assert(authVotesSource.includes("isTrustedMutationOrigin"));
+assert(voteStoreSource.includes("PRIMARY KEY (loop_slug, voter_key)"));
+assert(voteStoreSource.includes("CHECK (value IN (-1, 1))"));
 
 // Publishing, backup, rendering, and activation all terminate at the database.
 assert(loopRoutesSource.includes('"/admin/loops/export"'));
@@ -197,9 +219,15 @@ assert.equal(wrangler.workers_dev, true);
 assert.equal(wrangler.routes, undefined);
 assert.equal(wrangler.durable_objects.bindings[1].name, "LOOP_CATALOG");
 assert.equal(wrangler.durable_objects.bindings[1].class_name, "LoopCatalog");
+assert.equal(wrangler.durable_objects.bindings[2].name, "VOTE_STORE");
+assert.equal(wrangler.durable_objects.bindings[2].class_name, "VoteStore");
 assert.deepEqual(wrangler.migrations[1], {
   tag: "v2",
   new_sqlite_classes: ["LoopCatalog"],
+});
+assert.deepEqual(wrangler.migrations[2], {
+  tag: "v3",
+  new_sqlite_classes: ["VoteStore"],
 });
 assert.match(wrangler.vars.BOOTSTRAP_CATALOG_DIGEST, /^[a-f0-9]{64}$/);
 assert.equal(wrangler.vars.BOOTSTRAP_LOOP_COUNT, "50");
@@ -211,6 +239,8 @@ assert.deepEqual(Object.keys(proxyManifest.proxies).sort(), [
   "/",
   "/api/loops",
   "/api/loops/*",
+  "/api/votes",
+  "/auth/*",
   "/catalog.json",
   "/catalog.md",
   "/catalog.txt",
@@ -221,7 +251,7 @@ assert.deepEqual(Object.keys(proxyManifest.proxies).sort(), [
 ]);
 for (const proxy of Object.values(proxyManifest.proxies)) {
   assert.match(proxy.upstream, /^https:\/\/loop-library-forms\.mberman84\.workers\.dev\/loop-library(?:\/|$)/);
-  assert.equal(proxy.rateLimit, "600/hour/ip");
+  assert(["120/hour/ip", "600/hour/ip"].includes(proxy.rateLimit));
 }
 
 assert.match(skillSource, /The live catalog is the\s+source of truth/);

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -125,15 +125,15 @@ for (const value of [
 assert(html.includes("Search the library"));
 assert(html.includes("Search by title, task, or contributor"));
 assert(html.includes('class="search-field"'));
-assert(html.includes("styles.css?v=20260623-popular-ranking"));
-assert(html.includes("script.js?v=20260623-popular-ranking"));
+assert(html.includes("styles.css?v=20260623-auth-gate"));
+assert(html.includes("script.js?v=20260623-auth-gate"));
 assert(css.includes(".search-control-label"));
 assert(css.includes(".search-control:hover .search-field"));
 assert(css.includes(".search-control:focus-within .search-field"));
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
 for (const page of [learnHtml, agentHtml]) {
-  assert(page.includes("styles.css?v=20260623-popular-ranking"));
-  assert(page.includes("script.js?v=20260623-popular-ranking"));
+  assert(page.includes("styles.css?v=20260623-auth-gate"));
+  assert(page.includes("script.js?v=20260623-auth-gate"));
 }
 for (const page of [html, learnHtml, agentHtml]) {
   const brandPosition = page.indexOf('class="brand-lockup"');
@@ -187,6 +187,9 @@ assert(css.includes(".vote-controls"));
 assert(css.includes(".login-dialog"));
 assert(rendererSource.includes("renderVoteControls(loop.slug)"));
 assert(rendererSource.includes('class="vote-label"'));
+assert(rendererSource.includes('aria-label="Vote on this loop" hidden'));
+assert(browserScript.includes("setVotingUiVisible(body.uiEnabled === true)"));
+assert(css.includes(".vote-controls[hidden]"));
 assert(authVotesSource.includes('scope: "read:user"'));
 assert(!authVotesSource.includes("X_OAUTH"));
 assert(!authVotesSource.includes('"/auth/x"'));
@@ -235,6 +238,7 @@ assert.equal(wrangler.vars.PUBLIC_ORIGIN_URL, "https://calm-mortar-jtek.here.now
 assert.equal(wrangler.vars.PUBLIC_SHELL_URL, "https://calm-mortar-jtek.here.now/index.html");
 assert.equal(wrangler.vars.PUBLIC_SITE_HOSTNAME, "signals.forwardfuture.ai");
 assert.equal(wrangler.vars.PUBLIC_SITE_PATH, "/loop-library");
+assert.equal(wrangler.vars.VOTING_UI_ENABLED, "false");
 assert.deepEqual(Object.keys(proxyManifest.proxies).sort(), [
   "/",
   "/api/loops",

--- a/site/.herenow/proxy.json
+++ b/site/.herenow/proxy.json
@@ -39,6 +39,14 @@
     "/api/loops/*": {
       "upstream": "https://loop-library-forms.mberman84.workers.dev/loop-library/api/loops",
       "rateLimit": "600/hour/ip"
+    },
+    "/api/votes": {
+      "upstream": "https://loop-library-forms.mberman84.workers.dev/loop-library/api/votes",
+      "rateLimit": "600/hour/ip"
+    },
+    "/auth/*": {
+      "upstream": "https://loop-library-forms.mberman84.workers.dev/loop-library/auth",
+      "rateLimit": "120/hour/ip"
     }
   }
 }

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -76,8 +76,8 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260622-centered-host-credit" />
-    <script src="../script.js?v=20260622-url-state" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260623-popular-ranking" />
+    <script src="../script.js?v=20260623-popular-ranking" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -76,8 +76,8 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260623-popular-ranking" />
-    <script src="../script.js?v=20260623-popular-ranking" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260623-auth-gate" />
+    <script src="../script.js?v=20260623-auth-gate" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260622-sort-focus" />
+    <link rel="stylesheet" href="./styles.css?v=20260623-popular-ranking" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -198,7 +198,7 @@
   ]
 }
     </script>
-    <script src="./script.js?v=20260622-sort-focus" defer></script>
+    <script src="./script.js?v=20260623-popular-ranking" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>
@@ -429,7 +429,7 @@
             <label class="sort-control" for="loop-sort">
               <span>Sort</span>
               <select id="loop-sort">
-                <option value="featured">Featured first</option>
+                <option value="featured">Featured, then popular</option>
                 <option value="newest">Newest → oldest</option>
                 <option value="oldest">Oldest → newest</option>
                 <option value="alphabetical">A–Z</option>

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260623-popular-ranking" />
+    <link rel="stylesheet" href="./styles.css?v=20260623-auth-gate" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -198,7 +198,7 @@
   ]
 }
     </script>
-    <script src="./script.js?v=20260623-popular-ranking" defer></script>
+    <script src="./script.js?v=20260623-auth-gate" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -74,8 +74,8 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260622-centered-host-credit" />
-    <script src="../script.js?v=20260622-url-state" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260623-popular-ranking" />
+    <script src="../script.js?v=20260623-popular-ranking" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -74,8 +74,8 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260623-popular-ranking" />
-    <script src="../script.js?v=20260623-popular-ranking" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260623-auth-gate" />
+    <script src="../script.js?v=20260623-auth-gate" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/script.js
+++ b/site/script.js
@@ -110,6 +110,13 @@ function compareNewest(a, b) {
   return loopRowPositions.get(b) - loopRowPositions.get(a);
 }
 
+function comparePopular(a, b) {
+  const upvoteDifference =
+    Number(b.dataset.upvotes || 0) - Number(a.dataset.upvotes || 0);
+
+  return upvoteDifference !== 0 ? upvoteDifference : compareNewest(a, b);
+}
+
 function compareOldest(a, b) {
   const publishedDifference = (a.dataset.published ?? "").localeCompare(
     b.dataset.published ?? "",
@@ -131,11 +138,7 @@ function compareFeatured(a, b) {
     return featuredDifference;
   }
 
-  if (a.dataset.featured === "true") {
-    return loopRowPositions.get(a) - loopRowPositions.get(b);
-  }
-
-  return compareNewest(a, b);
+  return comparePopular(a, b);
 }
 
 function applySort(sort) {
@@ -596,6 +599,233 @@ document.querySelectorAll("[data-copy-social-post]").forEach((button) => {
     }
   });
 });
+
+const voteControls = [...document.querySelectorAll("[data-vote-controls]")];
+const LOOP_LIBRARY_PATH = window.location.pathname === "/loop-library" ||
+  window.location.pathname.startsWith("/loop-library/")
+  ? "/loop-library"
+  : "";
+const VOTE_API_URL = `${LOOP_LIBRARY_PATH}/api/votes`;
+let voteViewer = null;
+let viewerVotes = {};
+let loginDialog;
+
+function voteLoginUrl(provider) {
+  const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  return `${LOOP_LIBRARY_PATH}/auth/${provider}?${new URLSearchParams({
+    return_to: returnTo,
+  })}`;
+}
+
+function createLoginDialog() {
+  if (loginDialog) {
+    return loginDialog;
+  }
+
+  const dialog = document.createElement("dialog");
+  dialog.className = "login-dialog";
+  dialog.setAttribute("aria-labelledby", "vote-login-title");
+
+  const panel = document.createElement("div");
+  panel.className = "login-dialog-panel";
+  const eyebrow = document.createElement("p");
+  eyebrow.className = "eyebrow";
+  eyebrow.textContent = "Community voting";
+  const title = document.createElement("h2");
+  title.id = "vote-login-title";
+  title.textContent = "Sign in to vote";
+  const explanation = document.createElement("p");
+  explanation.textContent =
+    "Use GitHub. One account gets one vote per loop, and you can change it anytime.";
+  const providers = document.createElement("div");
+  providers.className = "login-providers";
+
+  const githubLink = document.createElement("a");
+  githubLink.className = "login-provider login-provider-github";
+  githubLink.href = voteLoginUrl("github");
+  githubLink.textContent = "Continue with GitHub";
+  providers.append(githubLink);
+
+  const cancel = document.createElement("button");
+  cancel.className = "login-cancel";
+  cancel.type = "button";
+  cancel.textContent = "Not now";
+  cancel.addEventListener("click", () => dialog.close());
+  dialog.addEventListener("click", (event) => {
+    if (event.target === dialog) dialog.close();
+  });
+
+  panel.append(eyebrow, title, explanation, providers, cancel);
+  dialog.append(panel);
+  document.body.append(dialog);
+  loginDialog = dialog;
+  return dialog;
+}
+
+function showLoginDialog() {
+  const dialog = createLoginDialog();
+  if (typeof dialog.showModal === "function") {
+    dialog.showModal();
+  } else {
+    dialog.setAttribute("open", "");
+  }
+}
+
+function updateVoteControls(control, counts = {}, viewerVote = 0) {
+  const upvote = control.querySelector('[data-vote-value="1"]');
+  const downvote = control.querySelector('[data-vote-value="-1"]');
+  const upvoteCount = upvote?.querySelector("[data-vote-count]");
+  const downvoteCount = downvote?.querySelector("[data-vote-count]");
+  const row = control.closest(".loop-row");
+
+  if (upvoteCount) upvoteCount.textContent = String(counts.upvotes || 0);
+  if (downvoteCount) downvoteCount.textContent = String(counts.downvotes || 0);
+  if (row) row.dataset.upvotes = String(counts.upvotes || 0);
+  upvote?.setAttribute("aria-pressed", String(viewerVote === 1));
+  downvote?.setAttribute("aria-pressed", String(viewerVote === -1));
+  control.classList.toggle("has-upvote", viewerVote === 1);
+  control.classList.toggle("has-downvote", viewerVote === -1);
+}
+
+function clearViewerVoteSelection() {
+  voteControls.forEach((control) => {
+    control.classList.remove("has-upvote", "has-downvote");
+    control.querySelectorAll(".vote-button").forEach((button) => {
+      button.setAttribute("aria-pressed", "false");
+    });
+  });
+}
+
+function renderVoteAccount() {
+  const existing = document.querySelector("[data-vote-account]");
+  if (existing) existing.remove();
+  if (!voteViewer) return;
+
+  const account = document.createElement("div");
+  account.className = "vote-account";
+  account.dataset.voteAccount = "";
+  const label = document.createElement("span");
+  label.textContent = `Voting as GitHub: ${voteViewer.username}`;
+  const logout = document.createElement("button");
+  logout.type = "button";
+  logout.textContent = "Sign out";
+  logout.addEventListener("click", async () => {
+    const response = await fetch(`${LOOP_LIBRARY_PATH}/auth/logout`, {
+      method: "POST",
+      credentials: "same-origin",
+    });
+    if (!response.ok) {
+      showToast("Sign out failed. Try again.");
+      return;
+    }
+    voteViewer = null;
+    viewerVotes = {};
+    renderVoteAccount();
+    clearViewerVoteSelection();
+    showToast("Signed out.");
+  });
+  account.append(label, logout);
+
+  const anchor = document.querySelector(".results-line") ||
+    document.querySelector(".detail-actions");
+  anchor?.insertAdjacentElement("afterend", account);
+}
+
+async function loadVotes() {
+  if (voteControls.length === 0) return;
+
+  try {
+    const response = await fetch(VOTE_API_URL, {
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) throw new Error("Voting unavailable");
+    const body = await response.json();
+    voteViewer = body.viewer || null;
+    viewerVotes = body.viewerVotes || {};
+    voteControls.forEach((control) => {
+      const slug = control.dataset.loopSlug;
+      updateVoteControls(
+        control,
+        body.votes?.[slug],
+        viewerVotes[slug] || 0,
+      );
+    });
+    applySort(activeSort);
+    updateLibrary();
+    renderVoteAccount();
+  } catch {
+    voteControls.forEach((control) => {
+      control.querySelectorAll(".vote-button").forEach((button) => {
+        button.disabled = true;
+      });
+    });
+  }
+}
+
+voteControls.forEach((control) => {
+  control.querySelectorAll("[data-vote-value]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      if (!voteViewer) {
+        showLoginDialog();
+        return;
+      }
+
+      const slug = control.dataset.loopSlug;
+      const selectedValue = Number(button.dataset.voteValue);
+      const nextValue = viewerVotes[slug] === selectedValue ? 0 : selectedValue;
+      control.querySelectorAll(".vote-button").forEach((candidate) => {
+        candidate.disabled = true;
+      });
+
+      try {
+        const response = await fetch(
+          `${LOOP_LIBRARY_PATH}/api/loops/${encodeURIComponent(slug)}/vote`,
+          {
+            method: "POST",
+            credentials: "same-origin",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ value: nextValue }),
+          },
+        );
+        const body = await response.json();
+        if (response.status === 401) {
+          voteViewer = null;
+          viewerVotes = {};
+          renderVoteAccount();
+          clearViewerVoteSelection();
+          showLoginDialog();
+          return;
+        }
+        if (!response.ok) throw new Error(body.error || "Vote failed");
+        viewerVotes[slug] = body.vote;
+        updateVoteControls(control, body.counts, body.vote);
+        applySort(activeSort);
+        updateLibrary();
+        showToast(body.vote === 0 ? "Vote removed." : "Vote counted.");
+      } catch (error) {
+        showToast(error.message || "Vote failed. Try again.");
+      } finally {
+        control.querySelectorAll(".vote-button").forEach((candidate) => {
+          candidate.disabled = false;
+        });
+      }
+    });
+  });
+});
+
+const authError = new URLSearchParams(window.location.search).get("auth_error");
+if (authError) {
+  showToast("Sign-in did not finish. Please try again.");
+  const cleanUrl = new URL(window.location.href);
+  cleanUrl.searchParams.delete("auth_error");
+  window.history.replaceState(null, "", cleanUrl);
+}
+
+loadVotes();
 
 const skillCopyButton = document.querySelector("[data-copy-skill-command]");
 const skillInstallCommand = document.querySelector(

--- a/site/script.js
+++ b/site/script.js
@@ -696,6 +696,18 @@ function clearViewerVoteSelection() {
   });
 }
 
+function setVotingUiVisible(visible) {
+  voteControls.forEach((control) => {
+    control.hidden = !visible;
+    control.querySelectorAll(".vote-button").forEach((button) => {
+      button.disabled = !visible;
+    });
+  });
+  if (!visible) {
+    document.querySelector("[data-vote-account]")?.remove();
+  }
+}
+
 function renderVoteAccount() {
   const existing = document.querySelector("[data-vote-account]");
   if (existing) existing.remove();
@@ -751,15 +763,12 @@ async function loadVotes() {
         viewerVotes[slug] || 0,
       );
     });
+    setVotingUiVisible(body.uiEnabled === true);
     applySort(activeSort);
     updateLibrary();
-    renderVoteAccount();
+    if (body.uiEnabled === true) renderVoteAccount();
   } catch {
-    voteControls.forEach((control) => {
-      control.querySelectorAll(".vote-button").forEach((button) => {
-        button.disabled = true;
-      });
-    });
+    setVotingUiVisible(false);
   }
 }
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -495,9 +495,8 @@ code {
   align-items: center;
   gap: clamp(18px, 3vw, 32px);
   margin-top: 24px;
-  padding: 16px 18px;
-  border: 1px solid var(--line);
-  border-left: 5px solid var(--orange);
+  padding: 18px 20px;
+  border-left: 3px solid var(--orange);
   color: var(--ink);
   background: var(--surface-muted);
   grid-template-columns: minmax(0, 0.75fr) minmax(360px, 1.25fr);
@@ -534,7 +533,6 @@ code {
 .skill-install-command {
   display: block;
   padding: 10px 12px;
-  border: 1px solid var(--line);
   color: var(--ink);
   background: var(--surface);
   font-size: 0.7rem;
@@ -608,11 +606,10 @@ code {
   display: flex;
   align-items: stretch;
   flex-direction: column;
-  gap: 14px;
+  gap: 18px;
   margin-top: 32px;
-  padding: 16px 0;
-  border-top: 1px solid var(--ink);
-  border-bottom: 1px solid var(--ink);
+  padding: 18px;
+  background: var(--surface-muted);
 }
 
 .search-control {
@@ -624,9 +621,10 @@ code {
 .search-control-label {
   display: block;
   width: max-content;
-  padding: 5px 9px;
-  color: var(--charcoal);
-  background: var(--orange);
+  padding: 0;
+  margin-bottom: 8px;
+  color: var(--muted);
+  background: transparent;
   font-family: var(--font-mono);
   font-size: 0.66rem;
   font-weight: 700;
@@ -641,7 +639,7 @@ code {
   align-items: center;
   gap: 12px;
   padding: 0 14px;
-  border: 2px solid var(--ink);
+  border: 1px solid var(--line);
   background: var(--surface);
 }
 
@@ -650,12 +648,13 @@ code {
 }
 
 .search-control:hover .search-field {
-  border-color: var(--orange);
+  border-color: var(--ink);
 }
 
 .search-control:focus-within .search-field {
-  outline: 3px solid var(--orange);
-  outline-offset: 3px;
+  border-color: var(--orange);
+  outline: 2px solid var(--orange);
+  outline-offset: 2px;
 }
 
 .search-field svg {
@@ -703,9 +702,9 @@ code {
 .category-filter {
   min-height: 32px;
   padding: 6px 10px;
-  border: 1px solid var(--ink);
+  border: 0;
   color: var(--ink);
-  background: transparent;
+  background: var(--surface);
   cursor: pointer;
   font-family: var(--font-mono);
   font-size: 0.62rem;
@@ -742,7 +741,7 @@ code {
 .sort-control select {
   min-height: 32px;
   padding: 6px 8px;
-  border: 1px solid var(--ink);
+  border: 0;
   border-radius: 0;
   color: var(--ink);
   background: var(--surface);
@@ -776,7 +775,7 @@ code {
 .results-line {
   display: flex;
   justify-content: space-between;
-  padding: 14px 0;
+  padding: 18px 4px 10px;
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: 0.62rem;
@@ -791,13 +790,13 @@ code {
 .table-wrap {
   width: 100%;
   overflow-x: auto;
-  border-top: 2px solid var(--ink);
 }
 
 .loop-table {
   width: 100%;
-  border-collapse: collapse;
-  background: var(--surface);
+  border-collapse: separate;
+  border-spacing: 0 10px;
+  background: transparent;
 }
 
 .loop-table {
@@ -805,8 +804,8 @@ code {
 }
 
 .loop-table th {
-  padding: 11px 18px;
-  border-bottom: 1px solid var(--ink);
+  padding: 0;
+  border: 0;
   font-family: var(--font-mono);
   font-size: 0.62rem;
   font-weight: 600;
@@ -815,13 +814,25 @@ code {
   text-transform: uppercase;
 }
 
+.loop-table thead {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
 .loop-table th:nth-child(2) {
   width: 124px;
 }
 
 .loop-table td {
-  padding: 18px;
-  border-bottom: 1px solid var(--line);
+  padding: 22px 20px;
+  border: 0;
+  background: var(--surface);
   vertical-align: top;
 }
 
@@ -883,14 +894,15 @@ code {
 
 .loop-title-link {
   scroll-margin-top: 80px;
-  text-decoration-color: var(--orange);
-  text-decoration-thickness: 2px;
+  text-decoration: none;
   text-underline-offset: 4px;
 }
 
 .loop-title-link:hover,
 .loop-title-link:focus-visible {
-  text-decoration-thickness: 4px;
+  text-decoration: underline;
+  text-decoration-color: var(--orange);
+  text-decoration-thickness: 2px;
 }
 
 .cell-loop p {
@@ -935,17 +947,200 @@ code {
 }
 
 .cell-action {
+  display: flex;
+  align-items: flex-end;
+  flex-direction: column;
+  gap: 8px;
   text-align: right;
 }
 
+.vote-controls {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  gap: 1px;
+  padding: 2px;
+  color: var(--muted);
+  background: var(--surface-muted);
+}
+
+.vote-label {
+  padding: 0 5px 0 6px;
+  font-family: var(--font-mono);
+  font-size: 0.57rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.vote-button {
+  display: inline-flex;
+  min-width: 38px;
+  min-height: 28px;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 6px;
+  border: 0;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.67rem;
+  font-weight: 700;
+  opacity: 0.88;
+}
+
+.vote-button svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+  stroke-width: 2;
+}
+
+.vote-button:hover,
+.vote-button:focus-visible,
+.vote-button[aria-pressed="true"] {
+  color: var(--ink);
+  background: var(--surface);
+  opacity: 1;
+}
+
+.vote-button[aria-pressed="true"] {
+  color: var(--orange);
+}
+
+.vote-button:focus-visible {
+  position: relative;
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.vote-button:disabled {
+  cursor: wait;
+  opacity: 0.5;
+}
+
+.vote-account {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 8px 0;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+}
+
+.vote-account button {
+  padding: 3px 0;
+  border: 0;
+  border-bottom: 1px solid currentColor;
+  color: var(--ink);
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+}
+
+.detail-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.detail-actions .share-actions {
+  margin-top: 0;
+}
+
+.login-dialog {
+  width: min(480px, calc(100vw - 32px));
+  padding: 0;
+  border: 1px solid var(--ink);
+  color: var(--ink);
+  background: var(--surface);
+}
+
+.login-dialog::backdrop {
+  background: rgba(16, 16, 16, 0.72);
+  backdrop-filter: blur(3px);
+}
+
+.login-dialog-panel {
+  padding: clamp(24px, 5vw, 36px);
+}
+
+.login-dialog h2 {
+  margin-bottom: 10px;
+  font-size: clamp(2rem, 5vw, 2.7rem);
+  letter-spacing: -0.055em;
+  line-height: 1;
+}
+
+.login-dialog-panel > p:not(.eyebrow) {
+  color: var(--muted);
+}
+
+.login-providers {
+  display: grid;
+  gap: 10px;
+  margin: 24px 0 18px;
+}
+
+.login-provider {
+  display: flex;
+  min-height: 46px;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border: 1px solid var(--ink);
+  color: var(--solid-foreground);
+  background: var(--solid-background);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.login-provider:hover,
+.login-provider:focus-visible {
+  color: var(--charcoal);
+  background: var(--orange);
+}
+
+.login-cancel {
+  padding: 4px 0;
+  border: 0;
+  border-bottom: 1px solid currentColor;
+  color: var(--ink);
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
 .copy-button {
-  padding: 7px 9px;
+  min-height: 38px;
+  padding: 9px 13px;
+  border-color: var(--solid-background);
+  color: var(--solid-foreground);
+  background: var(--solid-background);
+  font-weight: 700;
 }
 
 .copy-button:hover,
 .copy-button:focus-visible {
-  color: var(--solid-foreground);
-  background: var(--solid-background);
+  color: var(--charcoal);
+  background: var(--orange);
 }
 
 .empty-state {
@@ -2059,6 +2254,9 @@ code {
   }
 
   .cell-action {
+    align-items: flex-start;
+    flex-direction: row;
+    flex-wrap: wrap;
     grid-area: action;
     text-align: left;
   }

--- a/site/styles.css
+++ b/site/styles.css
@@ -964,6 +964,10 @@ code {
   background: var(--surface-muted);
 }
 
+.vote-controls[hidden] {
+  display: none;
+}
+
 .vote-label {
   padding: 0 5px 0 6px;
   font-family: var(--font-mono);

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -4,3 +4,7 @@ TURNSTILE_HOSTNAMES=localhost,127.0.0.1,dummy-key-pass
 HERENOW_API_KEY=replace-with-a-development-api-key
 HERENOW_SITE_SLUG=replace-with-a-development-site-slug
 LOOP_PUBLISH_TOKEN=replace-with-a-long-random-publishing-token
+SESSION_SECRET=replace-with-at-least-32-random-characters
+GITHUB_OAUTH_CLIENT_ID=replace-with-a-github-oauth-client-id
+GITHUB_OAUTH_CLIENT_SECRET=replace-with-a-github-oauth-client-secret
+OAUTH_CALLBACK_ORIGIN=https://signals.forwardfuture.ai

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -8,3 +8,4 @@ SESSION_SECRET=replace-with-at-least-32-random-characters
 GITHUB_OAUTH_CLIENT_ID=replace-with-a-github-oauth-client-id
 GITHUB_OAUTH_CLIENT_SECRET=replace-with-a-github-oauth-client-secret
 OAUTH_CALLBACK_ORIGIN=https://signals.forwardfuture.ai
+VOTING_UI_ENABLED=true

--- a/worker/package.json
+++ b/worker/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "node --check src/index.js && node --check bin/publish-loop.mjs && node --check bin/import-bootstrap.mjs && node --check bin/export-catalog.mjs && node --check bin/restore-catalog.mjs && node --test",
+    "check": "node --check src/index.js && node --check src/auth-votes.js && node --check src/vote-store.js && node --check bin/publish-loop.mjs && node --check bin/import-bootstrap.mjs && node --check bin/export-catalog.mjs && node --check bin/restore-catalog.mjs && node --test",
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
     "loop:publish": "node bin/publish-loop.mjs",

--- a/worker/src/auth-votes.js
+++ b/worker/src/auth-votes.js
@@ -1,0 +1,516 @@
+const SESSION_COOKIE = "ll_session";
+const OAUTH_COOKIE = "ll_oauth";
+const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+const OAUTH_TTL_SECONDS = 10 * 60;
+const MAX_VOTE_BODY_BYTES = 1024;
+
+export async function handleAuthVoteRoute(
+  request,
+  env,
+  dependencies = { fetch: (...args) => globalThis.fetch(...args) },
+) {
+  const url = new URL(request.url);
+  const path = stripBasePath(url.pathname, env.PUBLIC_SITE_PATH || "/loop-library");
+  const voteMatch = path.match(/^\/api\/loops\/([a-z0-9-]+)\/vote$/);
+  const recognized =
+    path === "/api/votes" ||
+    path === "/auth/session" ||
+    path === "/auth/logout" ||
+    path === "/auth/github" ||
+    path === "/auth/callback/github" ||
+    voteMatch;
+
+  if (!recognized) return null;
+
+  if (path === "/api/votes") {
+    if (request.method !== "GET") return methodNotAllowed("GET");
+    if (!env.VOTE_STORE) return unavailable("Voting is not configured.");
+
+    const viewer = await readSession(request, env);
+    const response = await voteStoreFetch(
+      env,
+      `/votes${viewer ? `?voter=${encodeURIComponent(viewer.sub)}` : ""}`,
+    );
+    const body = await response.json();
+    return jsonResponse({
+      ...body,
+      viewer: publicViewer(viewer),
+    });
+  }
+
+  if (path === "/auth/session") {
+    if (request.method !== "GET") return methodNotAllowed("GET");
+    return jsonResponse({ viewer: publicViewer(await readSession(request, env)) });
+  }
+
+  if (path === "/auth/logout") {
+    if (request.method !== "POST") return methodNotAllowed("POST");
+    if (!isTrustedMutationOrigin(request, env)) return forbidden();
+    return jsonResponse(
+      { ok: true },
+      200,
+      { "Set-Cookie": clearCookie(SESSION_COOKIE, env) },
+    );
+  }
+
+  if (path === "/auth/github") {
+    if (request.method !== "GET") return methodNotAllowed("GET");
+    return startOAuth(url, env);
+  }
+
+  if (path === "/auth/callback/github") {
+    if (request.method !== "GET") return methodNotAllowed("GET");
+    return finishOAuth(
+      request,
+      url,
+      env,
+      dependencies.fetch,
+    );
+  }
+
+  if (voteMatch) {
+    if (request.method !== "POST") return methodNotAllowed("POST");
+    if (!isTrustedMutationOrigin(request, env)) return forbidden();
+    if (!env.VOTE_STORE || !env.LOOP_CATALOG) {
+      return unavailable("Voting is not configured.");
+    }
+
+    const viewer = await readSession(request, env);
+    if (!viewer) {
+      return jsonResponse(
+        { error: "Sign in with GitHub to vote.", code: "authentication_required" },
+        401,
+      );
+    }
+
+    const value = await readVoteValue(request);
+    if (value instanceof Response) return value;
+
+    const slug = voteMatch[1];
+    if (!(await isPublishedLoop(env, slug))) {
+      return jsonResponse(
+        { error: "Loop not found", code: "not_found" },
+        404,
+      );
+    }
+
+    const response = await voteStoreFetch(env, `/votes/${slug}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        value,
+        voterKey: viewer.sub,
+        provider: viewer.provider,
+        username: viewer.username,
+      }),
+    });
+    return new Response(response.body, {
+      status: response.status,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  }
+
+  return null;
+}
+
+async function startOAuth(requestUrl, env) {
+  const configuration = githubConfiguration(env);
+  if (configuration instanceof Response) return configuration;
+  if (!env.SESSION_SECRET || env.SESSION_SECRET.length < 32) {
+    return unavailable("Login is not configured.");
+  }
+
+  const state = randomUrlSafe(32);
+  const returnTo = safeReturnTo(
+    requestUrl.searchParams.get("return_to"),
+    env,
+  );
+  const oauthCookie = await signedValue(
+    {
+      provider: "github",
+      state,
+      returnTo,
+      exp: Math.floor(Date.now() / 1000) + OAUTH_TTL_SECONDS,
+    },
+    env.SESSION_SECRET,
+  );
+  const callback = callbackUrl(env);
+  const authorizationUrl = new URL("https://github.com/login/oauth/authorize");
+  authorizationUrl.search = new URLSearchParams({
+    client_id: configuration.clientId,
+    redirect_uri: callback,
+    scope: "read:user",
+    state,
+  });
+
+  return redirect(authorizationUrl.toString(), {
+    "Set-Cookie": setCookie(OAUTH_COOKIE, oauthCookie, OAUTH_TTL_SECONDS, env),
+  });
+}
+
+async function finishOAuth(request, requestUrl, env, fetcher) {
+  const oauth = await readSignedCookie(request, OAUTH_COOKIE, env.SESSION_SECRET);
+  const fallback = safeReturnTo(null, env);
+  const returnTo = oauth?.returnTo || fallback;
+  const clearOAuth = clearCookie(OAUTH_COOKIE, env);
+
+  if (
+    !oauth ||
+    oauth.provider !== "github" ||
+    !requestUrl.searchParams.get("state") ||
+    !timingSafeEqual(oauth.state, requestUrl.searchParams.get("state"))
+  ) {
+    return redirect(authErrorUrl(returnTo, "invalid_state", env), {
+      "Set-Cookie": clearOAuth,
+    });
+  }
+
+  if (requestUrl.searchParams.get("error")) {
+    return redirect(authErrorUrl(returnTo, "access_denied", env), {
+      "Set-Cookie": clearOAuth,
+    });
+  }
+
+  const code = requestUrl.searchParams.get("code");
+  if (!code) {
+    return redirect(authErrorUrl(returnTo, "missing_code", env), {
+      "Set-Cookie": clearOAuth,
+    });
+  }
+
+  try {
+    const configuration = githubConfiguration(env);
+    if (configuration instanceof Response) return configuration;
+    const identity = await githubIdentity(
+      code,
+      configuration,
+      callbackUrl(env),
+      fetcher,
+    );
+    const session = await signedValue(
+      {
+        v: 1,
+        sub: `github:${identity.id}`,
+        provider: "github",
+        username: identity.username,
+        name: identity.name,
+        exp: Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS,
+      },
+      env.SESSION_SECRET,
+    );
+    const headers = new Headers({
+      "Cache-Control": "no-store",
+      Location: absoluteReturnTo(returnTo, env),
+      "Referrer-Policy": "no-referrer",
+    });
+    headers.append(
+      "Set-Cookie",
+      setCookie(SESSION_COOKIE, session, SESSION_TTL_SECONDS, env),
+    );
+    headers.append("Set-Cookie", clearOAuth);
+    return new Response(null, { status: 302, headers });
+  } catch (error) {
+    console.error("OAuth login failed", {
+      provider: "github",
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return redirect(authErrorUrl(returnTo, "provider_error", env), {
+      "Set-Cookie": clearOAuth,
+    });
+  }
+}
+
+async function githubIdentity(code, configuration, redirectUri, fetcher) {
+  const tokenResponse = await fetcher("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: configuration.clientId,
+      client_secret: configuration.clientSecret,
+      code,
+      redirect_uri: redirectUri,
+    }),
+  });
+  const token = await tokenResponse.json();
+  if (!tokenResponse.ok || !token.access_token) throw new Error("GitHub token exchange failed");
+
+  const profileResponse = await fetcher("https://api.github.com/user", {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token.access_token}`,
+      "User-Agent": "Forward-Future-Loop-Library",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  const profile = await profileResponse.json();
+  if (!profileResponse.ok || !profile.id || !profile.login) {
+    throw new Error("GitHub profile lookup failed");
+  }
+  return {
+    id: String(profile.id),
+    username: String(profile.login).slice(0, 80),
+    name: String(profile.name || profile.login).slice(0, 100),
+  };
+}
+
+function githubConfiguration(env) {
+  if (!env.GITHUB_OAUTH_CLIENT_ID || !env.GITHUB_OAUTH_CLIENT_SECRET) {
+    return unavailable("GitHub login is not configured.");
+  }
+  return {
+    clientId: env.GITHUB_OAUTH_CLIENT_ID,
+    clientSecret: env.GITHUB_OAUTH_CLIENT_SECRET,
+  };
+}
+
+async function readSession(request, env) {
+  if (!env.SESSION_SECRET) return null;
+  const session = await readSignedCookie(request, SESSION_COOKIE, env.SESSION_SECRET);
+  if (
+    !session ||
+    session.v !== 1 ||
+    !/^github:[A-Za-z0-9_-]{1,128}$/.test(session.sub || "") ||
+    session.provider !== "github" ||
+    typeof session.username !== "string"
+  ) {
+    return null;
+  }
+  return session;
+}
+
+function publicViewer(viewer) {
+  return viewer
+    ? {
+        provider: viewer.provider,
+        username: viewer.username,
+        name: viewer.name,
+      }
+    : null;
+}
+
+async function readVoteValue(request) {
+  const length = Number(request.headers.get("Content-Length") || 0);
+  if (Number.isFinite(length) && length > MAX_VOTE_BODY_BYTES) {
+    return jsonResponse({ error: "Vote is too large", code: "invalid_vote" }, 413);
+  }
+  try {
+    const text = await request.text();
+    if (new TextEncoder().encode(text).byteLength > MAX_VOTE_BODY_BYTES) {
+      return jsonResponse({ error: "Vote is too large", code: "invalid_vote" }, 413);
+    }
+    const body = JSON.parse(text);
+    if (!body || ![-1, 0, 1].includes(body.value)) throw new Error("invalid");
+    return body.value;
+  } catch {
+    return jsonResponse({ error: "Invalid vote", code: "invalid_vote" }, 400);
+  }
+}
+
+async function isPublishedLoop(env, slug) {
+  const id = env.LOOP_CATALOG.idFromName("production");
+  const response = await env.LOOP_CATALOG.get(id).fetch("https://loop-catalog/published");
+  if (!response.ok) return false;
+  const catalog = await response.json();
+  return catalog.initialized && catalog.loops.some((loop) => loop.slug === slug);
+}
+
+function voteStoreFetch(env, path, init) {
+  const id = env.VOTE_STORE.idFromName("production");
+  return env.VOTE_STORE.get(id).fetch(`https://vote-store${path}`, init);
+}
+
+function isTrustedMutationOrigin(request, env) {
+  const origin = request.headers.get("Origin");
+  if (!origin) return false;
+  const allowed = new Set([
+    `https://${env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.ai"}`,
+    "http://localhost:4173",
+    "http://127.0.0.1:4173",
+  ]);
+  return allowed.has(origin);
+}
+
+function safeReturnTo(value, env) {
+  const base = normalizeBasePath(env.PUBLIC_SITE_PATH || "/loop-library");
+  if (
+    typeof value === "string" &&
+    value.startsWith(`${base}/`) &&
+    !value.startsWith("//") &&
+    !value.includes("\\")
+  ) {
+    return value.slice(0, 1000);
+  }
+  return `${base}/`;
+}
+
+function callbackUrl(env) {
+  return `${canonicalOrigin(env)}${normalizeBasePath(
+    env.PUBLIC_SITE_PATH || "/loop-library",
+  )}/auth/callback/github`;
+}
+
+function absoluteReturnTo(returnTo, env) {
+  return new URL(returnTo, `${canonicalOrigin(env)}/`).toString();
+}
+
+function authErrorUrl(returnTo, code, env) {
+  const url = new URL(absoluteReturnTo(returnTo, env));
+  url.searchParams.set("auth_error", code);
+  return url.toString();
+}
+
+function canonicalOrigin(env) {
+  return env.OAUTH_CALLBACK_ORIGIN ||
+    `https://${env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.ai"}`;
+}
+
+function normalizeBasePath(value) {
+  const segments = String(value).split("/").filter(Boolean);
+  return segments.length ? `/${segments.join("/")}` : "";
+}
+
+function stripBasePath(pathname, basePath) {
+  const normalized = normalizeBasePath(basePath);
+  if (pathname === normalized || pathname === `${normalized}/`) return "/";
+  if (normalized && pathname.startsWith(`${normalized}/`)) {
+    return pathname.slice(normalized.length);
+  }
+  return pathname;
+}
+
+function setCookie(name, value, maxAge, env) {
+  return `${name}=${value}; Path=${cookiePath(env)}; Max-Age=${maxAge}; HttpOnly; Secure; SameSite=Lax`;
+}
+
+function clearCookie(name, env) {
+  return `${name}=; Path=${cookiePath(env)}; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;
+}
+
+function cookiePath(env) {
+  return `${normalizeBasePath(env.PUBLIC_SITE_PATH || "/loop-library") || "/"}/`.replace("//", "/");
+}
+
+function cookieValue(request, name) {
+  const cookies = request.headers.get("Cookie") || "";
+  for (const part of cookies.split(";")) {
+    const [key, ...rest] = part.trim().split("=");
+    if (key === name) return rest.join("=");
+  }
+  return "";
+}
+
+async function signedValue(payload, secret) {
+  const encoded = base64Url(JSON.stringify(payload));
+  return `${encoded}.${await hmac(encoded, secret)}`;
+}
+
+async function readSignedCookie(request, name, secret) {
+  if (!secret) return null;
+  const value = cookieValue(request, name);
+  const separator = value.lastIndexOf(".");
+  if (separator < 1) return null;
+  const encoded = value.slice(0, separator);
+  const signature = value.slice(separator + 1);
+  if (!timingSafeEqual(signature, await hmac(encoded, secret))) return null;
+  try {
+    const payload = JSON.parse(fromBase64Url(encoded));
+    if (!payload.exp || payload.exp <= Math.floor(Date.now() / 1000)) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+async function hmac(value, secret) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return base64UrlBytes(
+    new Uint8Array(await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(value))),
+  );
+}
+
+function randomUrlSafe(size) {
+  const bytes = new Uint8Array(size);
+  crypto.getRandomValues(bytes);
+  return base64UrlBytes(bytes);
+}
+
+function base64Url(value) {
+  return base64UrlBytes(new TextEncoder().encode(value));
+}
+
+function base64UrlBytes(bytes) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(value) {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/") +
+    "=".repeat((4 - (value.length % 4)) % 4);
+  const binary = atob(padded);
+  return new TextDecoder().decode(
+    Uint8Array.from(binary, (character) => character.charCodeAt(0)),
+  );
+}
+
+function timingSafeEqual(left, right) {
+  if (typeof left !== "string" || typeof right !== "string") return false;
+  let different = left.length ^ right.length;
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    different |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+  }
+  return different === 0;
+}
+
+function redirect(location, headers = {}) {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "Cache-Control": "no-store",
+      Location: location,
+      "Referrer-Policy": "no-referrer",
+      ...headers,
+    },
+  });
+}
+
+function jsonResponse(body, status = 200, headers = {}) {
+  return Response.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff",
+      ...headers,
+    },
+  });
+}
+
+function methodNotAllowed(allow) {
+  return jsonResponse(
+    { error: "Method not allowed", code: "method_not_allowed" },
+    405,
+    { Allow: allow },
+  );
+}
+
+function forbidden() {
+  return jsonResponse({ error: "Forbidden", code: "origin_not_allowed" }, 403);
+}
+
+function unavailable(message) {
+  return jsonResponse({ error: message, code: "not_configured" }, 503);
+}

--- a/worker/src/auth-votes.js
+++ b/worker/src/auth-votes.js
@@ -34,6 +34,7 @@ export async function handleAuthVoteRoute(
     const body = await response.json();
     return jsonResponse({
       ...body,
+      uiEnabled: env.VOTING_UI_ENABLED === "true",
       viewer: publicViewer(viewer),
     });
   }

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -2,8 +2,10 @@ import {
   handleLoopRoute,
   publicOriginRequest,
 } from "./loop-routes.js";
+import { handleAuthVoteRoute } from "./auth-votes.js";
 
 export { LoopCatalog } from "./catalog-store.js";
+export { VoteStore } from "./vote-store.js";
 
 const TURNSTILE_VERIFY_URL =
   "https://challenges.cloudflare.com/turnstile/v0/siteverify";
@@ -66,6 +68,16 @@ export async function handleRequest(
   _ctx,
   dependencies = { fetch: (...args) => globalThis.fetch(...args) },
 ) {
+  const authVoteResponse = await handleAuthVoteRoute(
+    request,
+    env,
+    dependencies,
+  );
+
+  if (authVoteResponse) {
+    return authVoteResponse;
+  }
+
   const loopResponse = await handleLoopRoute(request, env, dependencies);
 
   if (loopResponse) {

--- a/worker/src/render-loops.js
+++ b/worker/src/render-loops.js
@@ -82,6 +82,7 @@ export function renderHomepageRow(loop) {
                   <button class="copy-button" type="button">
                     <span>Copy loop</span>
                   </button>
+                  ${renderVoteControls(loop.slug)}
                 </td>
               </tr>`;
 }
@@ -310,9 +311,9 @@ export function renderLoopPage(loop, loops) {
     <link rel="alternate" type="text/plain" title="${SITE.name} plain-text catalog" href="${SITE.baseUrl}catalog.txt" />
     <link rel="help" href="${SITE.baseUrl}agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260621-author-byline" />
+    <link rel="stylesheet" href="../../styles.css?v=20260623-popular-ranking" />
     <script type="application/ld+json">${jsonForHtml(structuredData)}</script>
-    <script src="../../script.js?v=20260621-author-byline" defer></script>
+    <script src="../../script.js?v=20260623-popular-ranking" defer></script>
     <title>${escapeHtml(loop.seoTitle)}</title>
   </head>
   <body>
@@ -349,7 +350,10 @@ export function renderLoopPage(loop, loops) {
           <h1>${escapeHtml(loop.title)}</h1>
           <p class="detail-lede">${escapeHtml(loop.description)}</p>
           <p class="detail-byline">By <strong>${escapeHtml(loop.author)}</strong></p>
-          ${shareActions(loop, url)}
+          <div class="detail-actions">
+            ${renderVoteControls(loop.slug)}
+            ${shareActions(loop, url)}
+          </div>
         </header>
         <div class="detail-stack">
           <section class="detail-prompt-card" data-copy-root aria-labelledby="copy-loop">
@@ -383,6 +387,10 @@ export function renderLoopPage(loop, loops) {
 function shareActions(loop, url) {
   const text = `Try "${loop.title}" from the Loop Library: ${loop.summary}`;
   return `<div class="share-actions" aria-label="Share this loop"><button class="share-action share-action-primary" type="button" data-copy-social-post data-post-text="${escapeHtml(text)}" data-post-url="${escapeHtml(url)}" aria-label="Copy a social post about ${escapeHtml(loop.title)}"><svg class="share-copy-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="8" width="11" height="11"></rect><path d="M16 8V5a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h3"></path></svg><span>Share on social</span></button></div>`;
+}
+
+function renderVoteControls(slug) {
+  return `<div class="vote-controls" data-vote-controls data-loop-slug="${escapeHtml(slug)}" aria-label="Vote on this loop"><span class="vote-label" aria-hidden="true">Vote</span><button class="vote-button vote-button-up" type="button" data-vote-value="1" aria-label="Upvote this loop" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 5-7 8h4v6h6v-6h4Z"></path></svg><span data-vote-count>0</span></button><button class="vote-button vote-button-down" type="button" data-vote-value="-1" aria-label="Downvote this loop" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 19 7-8h-4V5H9v6H5Z"></path></svg><span data-vote-count>0</span></button></div>`;
 }
 
 function hereNowCredit(assetPath, modifier) {

--- a/worker/src/render-loops.js
+++ b/worker/src/render-loops.js
@@ -311,9 +311,9 @@ export function renderLoopPage(loop, loops) {
     <link rel="alternate" type="text/plain" title="${SITE.name} plain-text catalog" href="${SITE.baseUrl}catalog.txt" />
     <link rel="help" href="${SITE.baseUrl}agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260623-popular-ranking" />
+    <link rel="stylesheet" href="../../styles.css?v=20260623-auth-gate" />
     <script type="application/ld+json">${jsonForHtml(structuredData)}</script>
-    <script src="../../script.js?v=20260623-popular-ranking" defer></script>
+    <script src="../../script.js?v=20260623-auth-gate" defer></script>
     <title>${escapeHtml(loop.seoTitle)}</title>
   </head>
   <body>
@@ -390,7 +390,7 @@ function shareActions(loop, url) {
 }
 
 function renderVoteControls(slug) {
-  return `<div class="vote-controls" data-vote-controls data-loop-slug="${escapeHtml(slug)}" aria-label="Vote on this loop"><span class="vote-label" aria-hidden="true">Vote</span><button class="vote-button vote-button-up" type="button" data-vote-value="1" aria-label="Upvote this loop" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 5-7 8h4v6h6v-6h4Z"></path></svg><span data-vote-count>0</span></button><button class="vote-button vote-button-down" type="button" data-vote-value="-1" aria-label="Downvote this loop" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 19 7-8h-4V5H9v6H5Z"></path></svg><span data-vote-count>0</span></button></div>`;
+  return `<div class="vote-controls" data-vote-controls data-loop-slug="${escapeHtml(slug)}" aria-label="Vote on this loop" hidden><span class="vote-label" aria-hidden="true">Vote</span><button class="vote-button vote-button-up" type="button" data-vote-value="1" aria-label="Upvote this loop" aria-pressed="false" disabled><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 5-7 8h4v6h6v-6h4Z"></path></svg><span data-vote-count>0</span></button><button class="vote-button vote-button-down" type="button" data-vote-value="-1" aria-label="Downvote this loop" aria-pressed="false" disabled><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 19 7-8h-4V5H9v6H5Z"></path></svg><span data-vote-count>0</span></button></div>`;
 }
 
 function hereNowCredit(assetPath, modifier) {

--- a/worker/src/vote-store.js
+++ b/worker/src/vote-store.js
@@ -1,0 +1,146 @@
+function jsonResponse(body, status = 200) {
+  return Response.json(body, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+export class VoteStore {
+  constructor(state) {
+    this.state = state;
+    this.sql = state.storage.sql;
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS loop_votes (
+        loop_slug TEXT NOT NULL,
+        voter_key TEXT NOT NULL,
+        value INTEGER NOT NULL CHECK (value IN (-1, 1)),
+        provider TEXT NOT NULL CHECK (provider = 'github'),
+        username TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (loop_slug, voter_key)
+      );
+      CREATE INDEX IF NOT EXISTS loop_votes_slug
+        ON loop_votes(loop_slug, value);
+    `);
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (request.method === "GET" && url.pathname === "/votes") {
+      const voterKey = url.searchParams.get("voter") || "";
+      return jsonResponse({
+        votes: this.counts(),
+        viewerVotes: voterKey ? this.viewerVotes(voterKey) : {},
+      });
+    }
+
+    const voteMatch = url.pathname.match(/^\/votes\/([a-z0-9-]+)$/);
+
+    if (request.method === "POST" && voteMatch) {
+      const body = await request.json();
+
+      if (
+        !body ||
+        ![-1, 0, 1].includes(body.value) ||
+        !/^github:[A-Za-z0-9_-]{1,128}$/.test(body.voterKey || "") ||
+        body.provider !== "github" ||
+        !body.voterKey.startsWith(`${body.provider}:`) ||
+        typeof body.username !== "string" ||
+        body.username.length < 1 ||
+        body.username.length > 80
+      ) {
+        return jsonResponse(
+          { error: "Invalid vote", code: "invalid_vote" },
+          400,
+        );
+      }
+
+      const slug = voteMatch[1];
+      const now = new Date().toISOString();
+
+      this.state.storage.transactionSync(() => {
+        if (body.value === 0) {
+          this.sql.exec(
+            "DELETE FROM loop_votes WHERE loop_slug = ? AND voter_key = ?",
+            slug,
+            body.voterKey,
+          );
+          return;
+        }
+
+        this.sql.exec(
+          `INSERT INTO loop_votes (
+             loop_slug, voter_key, value, provider, username, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(loop_slug, voter_key) DO UPDATE SET
+             value = excluded.value,
+             provider = excluded.provider,
+             username = excluded.username,
+             updated_at = excluded.updated_at`,
+          slug,
+          body.voterKey,
+          body.value,
+          body.provider,
+          body.username,
+          now,
+          now,
+        );
+      });
+
+      return jsonResponse({
+        slug,
+        vote: body.value,
+        counts: this.countForSlug(slug),
+      });
+    }
+
+    return jsonResponse({ error: "Not found", code: "not_found" }, 404);
+  }
+
+  counts() {
+    return Object.fromEntries(
+      [...this.sql.exec(
+        `SELECT
+           loop_slug,
+           SUM(CASE WHEN value = 1 THEN 1 ELSE 0 END) AS upvotes,
+           SUM(CASE WHEN value = -1 THEN 1 ELSE 0 END) AS downvotes,
+           SUM(value) AS score
+         FROM loop_votes
+         GROUP BY loop_slug
+         ORDER BY loop_slug`,
+      )].map((row) => [row.loop_slug, normalizeCounts(row)]),
+    );
+  }
+
+  countForSlug(slug) {
+    const row = [...this.sql.exec(
+      `SELECT
+         SUM(CASE WHEN value = 1 THEN 1 ELSE 0 END) AS upvotes,
+         SUM(CASE WHEN value = -1 THEN 1 ELSE 0 END) AS downvotes,
+         SUM(value) AS score
+       FROM loop_votes
+       WHERE loop_slug = ?`,
+      slug,
+    )][0];
+    return normalizeCounts(row || {});
+  }
+
+  viewerVotes(voterKey) {
+    return Object.fromEntries(
+      [...this.sql.exec(
+        "SELECT loop_slug, value FROM loop_votes WHERE voter_key = ?",
+        voterKey,
+      )].map((row) => [row.loop_slug, row.value]),
+    );
+  }
+}
+
+function normalizeCounts(row) {
+  return {
+    upvotes: Number(row.upvotes || 0),
+    downvotes: Number(row.downvotes || 0),
+    score: Number(row.score || 0),
+  };
+}

--- a/worker/test/auth-votes.test.js
+++ b/worker/test/auth-votes.test.js
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { handleAuthVoteRoute } from "../src/auth-votes.js";
+
+const ORIGIN = "https://signals.forwardfuture.ai";
+const BASE = `${ORIGIN}/loop-library`;
+
+class MemoryVoteNamespace {
+  votes = new Map();
+
+  idFromName(name) {
+    return name;
+  }
+
+  get() {
+    return {
+      fetch: async (input, init = {}) => {
+        const url = new URL(input);
+        const match = url.pathname.match(/^\/votes\/([a-z0-9-]+)$/);
+
+        if (url.pathname === "/votes") {
+          const counts = {};
+          const viewerVotes = {};
+          const viewer = url.searchParams.get("voter");
+          for (const [key, value] of this.votes) {
+            const [slug, voterKey] = key.split("|");
+            counts[slug] ||= { upvotes: 0, downvotes: 0, score: 0 };
+            if (value === 1) counts[slug].upvotes += 1;
+            if (value === -1) counts[slug].downvotes += 1;
+            counts[slug].score += value;
+            if (viewer === voterKey) viewerVotes[slug] = value;
+          }
+          return Response.json({ votes: counts, viewerVotes });
+        }
+
+        if (match && init.method === "POST") {
+          const body = JSON.parse(init.body);
+          const key = `${match[1]}|${body.voterKey}`;
+          if (body.value === 0) this.votes.delete(key);
+          else this.votes.set(key, body.value);
+          const values = [...this.votes]
+            .filter(([entry]) => entry.startsWith(`${match[1]}|`))
+            .map(([, value]) => value);
+          return Response.json({
+            slug: match[1],
+            vote: body.value,
+            counts: {
+              upvotes: values.filter((value) => value === 1).length,
+              downvotes: values.filter((value) => value === -1).length,
+              score: values.reduce((sum, value) => sum + value, 0),
+            },
+          });
+        }
+
+        return Response.json({ error: "Not found" }, { status: 404 });
+      },
+    };
+  }
+}
+
+class MemoryCatalogNamespace {
+  idFromName(name) {
+    return name;
+  }
+
+  get() {
+    return {
+      fetch: async () => Response.json({
+        initialized: true,
+        loops: [{ slug: "overnight-docs-sweep" }],
+      }),
+    };
+  }
+}
+
+function makeEnv() {
+  return {
+    GITHUB_OAUTH_CLIENT_ID: "github-client-id",
+    GITHUB_OAUTH_CLIENT_SECRET: "github-client-secret",
+    LOOP_CATALOG: new MemoryCatalogNamespace(),
+    OAUTH_CALLBACK_ORIGIN: ORIGIN,
+    PUBLIC_SITE_HOSTNAME: "signals.forwardfuture.ai",
+    PUBLIC_SITE_PATH: "/loop-library",
+    SESSION_SECRET: "test-session-secret-that-is-more-than-32-characters",
+    VOTE_STORE: new MemoryVoteNamespace(),
+  };
+}
+
+function cookiePair(setCookie, name) {
+  const match = setCookie.match(new RegExp(`(?:^|, )(${name}=[^;]+)`));
+  assert(match, `${name} cookie missing from ${setCookie}`);
+  return match[1];
+}
+
+async function githubSession(env) {
+  const start = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/github?return_to=%2Floop-library%2Floops%2Fovernight-docs-sweep%2F`),
+    env,
+  );
+  assert.equal(start.status, 302);
+  const authorization = new URL(start.headers.get("Location"));
+  assert.equal(authorization.origin, "https://github.com");
+  assert.equal(authorization.searchParams.get("scope"), "read:user");
+  const state = authorization.searchParams.get("state");
+  const oauthCookie = cookiePair(start.headers.get("Set-Cookie"), "ll_oauth");
+  const calls = [];
+  const callback = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/callback/github?code=test-code&state=${state}`, {
+      headers: { Cookie: oauthCookie },
+    }),
+    env,
+    {
+      fetch: async (input, init = {}) => {
+        calls.push({ input, init });
+        if (input === "https://github.com/login/oauth/access_token") {
+          return Response.json({ access_token: "github-access-token" });
+        }
+        if (input === "https://api.github.com/user") {
+          return Response.json({ id: 42, login: "octoloop", name: "Octo Loop" });
+        }
+        throw new Error(`Unexpected request: ${input}`);
+      },
+    },
+  );
+  assert.equal(callback.status, 302);
+  assert.equal(
+    callback.headers.get("Location"),
+    `${BASE}/loops/overnight-docs-sweep/`,
+  );
+  assert.equal(calls.length, 2);
+  assert.equal(
+    new Headers(calls[1].init.headers).get("Authorization"),
+    "Bearer github-access-token",
+  );
+  return cookiePair(callback.headers.get("Set-Cookie"), "ll_session");
+}
+
+test("GitHub OAuth creates a signed session that can cast, switch, and remove a vote", async () => {
+  const env = makeEnv();
+  const sessionCookie = await githubSession(env);
+  const voteRequest = (value, origin = ORIGIN) => new Request(
+    `${BASE}/api/loops/overnight-docs-sweep/vote`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie,
+        Origin: origin,
+      },
+      body: JSON.stringify({ value }),
+    },
+  );
+
+  const upvote = await handleAuthVoteRoute(voteRequest(1), env);
+  assert.equal(upvote.status, 200);
+  assert.deepEqual((await upvote.json()).counts, {
+    upvotes: 1,
+    downvotes: 0,
+    score: 1,
+  });
+
+  const downvote = await handleAuthVoteRoute(voteRequest(-1), env);
+  assert.deepEqual((await downvote.json()).counts, {
+    upvotes: 0,
+    downvotes: 1,
+    score: -1,
+  });
+
+  const totals = await handleAuthVoteRoute(
+    new Request(`${BASE}/api/votes`, { headers: { Cookie: sessionCookie } }),
+    env,
+  );
+  const totalsBody = await totals.json();
+  assert.deepEqual(totalsBody.viewer, {
+    provider: "github",
+    username: "octoloop",
+    name: "Octo Loop",
+  });
+  assert.equal(totalsBody.viewerVotes["overnight-docs-sweep"], -1);
+
+  const removed = await handleAuthVoteRoute(voteRequest(0), env);
+  assert.deepEqual((await removed.json()).counts, {
+    upvotes: 0,
+    downvotes: 0,
+    score: 0,
+  });
+});
+
+test("vote writes reject anonymous, cross-site, malformed, and unpublished requests", async () => {
+  const env = makeEnv();
+  const anonymous = await handleAuthVoteRoute(
+    new Request(`${BASE}/api/loops/overnight-docs-sweep/vote`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: ORIGIN },
+      body: JSON.stringify({ value: 1 }),
+    }),
+    env,
+  );
+  assert.equal(anonymous.status, 401);
+
+  const sessionCookie = await githubSession(env);
+  const crossSite = await handleAuthVoteRoute(
+    new Request(`${BASE}/api/loops/overnight-docs-sweep/vote`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie,
+        Origin: "https://phishing.example",
+      },
+      body: JSON.stringify({ value: 1 }),
+    }),
+    env,
+  );
+  assert.equal(crossSite.status, 403);
+
+  const malformed = await handleAuthVoteRoute(
+    new Request(`${BASE}/api/loops/overnight-docs-sweep/vote`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie,
+        Origin: ORIGIN,
+      },
+      body: JSON.stringify({ value: 2 }),
+    }),
+    env,
+  );
+  assert.equal(malformed.status, 400);
+
+  const unpublished = await handleAuthVoteRoute(
+    new Request(`${BASE}/api/loops/not-published/vote`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie,
+        Origin: ORIGIN,
+      },
+      body: JSON.stringify({ value: 1 }),
+    }),
+    env,
+  );
+  assert.equal(unpublished.status, 404);
+});
+
+test("GitHub OAuth state is verified and X routes are absent", async () => {
+  const env = makeEnv();
+  const githubStart = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/github?return_to=%2Floop-library%2F`),
+    env,
+  );
+
+  const invalidCallback = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/callback/github?code=test-code&state=wrong-state`, {
+      headers: { Cookie: cookiePair(githubStart.headers.get("Set-Cookie"), "ll_oauth") },
+    }),
+    env,
+  );
+  assert.equal(invalidCallback.status, 302);
+  assert.match(invalidCallback.headers.get("Location"), /auth_error=invalid_state/);
+
+  assert.equal(
+    await handleAuthVoteRoute(new Request(`${BASE}/auth/x`), env),
+    null,
+  );
+});
+
+test("logout requires a trusted origin and clears the session", async () => {
+  const env = makeEnv();
+  const rejected = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/logout`, { method: "POST" }),
+    env,
+  );
+  assert.equal(rejected.status, 403);
+
+  const accepted = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/logout`, {
+      method: "POST",
+      headers: { Origin: ORIGIN },
+    }),
+    env,
+  );
+  assert.equal(accepted.status, 200);
+  assert.match(accepted.headers.get("Set-Cookie"), /ll_session=;/);
+  assert.match(accepted.headers.get("Set-Cookie"), /Max-Age=0/);
+});

--- a/worker/test/auth-votes.test.js
+++ b/worker/test/auth-votes.test.js
@@ -83,6 +83,7 @@ function makeEnv() {
     PUBLIC_SITE_HOSTNAME: "signals.forwardfuture.ai",
     PUBLIC_SITE_PATH: "/loop-library",
     SESSION_SECRET: "test-session-secret-that-is-more-than-32-characters",
+    VOTING_UI_ENABLED: "true",
     VOTE_STORE: new MemoryVoteNamespace(),
   };
 }
@@ -178,6 +179,7 @@ test("GitHub OAuth creates a signed session that can cast, switch, and remove a 
     name: "Octo Loop",
   });
   assert.equal(totalsBody.viewerVotes["overnight-docs-sweep"], -1);
+  assert.equal(totalsBody.uiEnabled, true);
 
   const removed = await handleAuthVoteRoute(voteRequest(0), env);
   assert.deepEqual((await removed.json()).counts, {
@@ -185,6 +187,31 @@ test("GitHub OAuth creates a signed session that can cast, switch, and remove a 
     downvotes: 0,
     score: 0,
   });
+});
+
+test("voting UI is fail-closed unless the launch flag is exactly true", async () => {
+  const env = makeEnv();
+  delete env.VOTING_UI_ENABLED;
+
+  const disabled = await handleAuthVoteRoute(
+    new Request(`${BASE}/api/votes`),
+    env,
+  );
+  assert.equal((await disabled.json()).uiEnabled, false);
+
+  env.VOTING_UI_ENABLED = "TRUE";
+  const malformed = await handleAuthVoteRoute(
+    new Request(`${BASE}/api/votes`),
+    env,
+  );
+  assert.equal((await malformed.json()).uiEnabled, false);
+
+  env.VOTING_UI_ENABLED = "true";
+  const enabled = await handleAuthVoteRoute(
+    new Request(`${BASE}/api/votes`),
+    env,
+  );
+  assert.equal((await enabled.json()).uiEnabled, true);
 });
 
 test("vote writes reject anonymous, cross-site, malformed, and unpublished requests", async () => {

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -22,6 +22,10 @@
       {
         "name": "LOOP_CATALOG",
         "class_name": "LoopCatalog"
+      },
+      {
+        "name": "VOTE_STORE",
+        "class_name": "VoteStore"
       }
     ]
   },
@@ -33,6 +37,10 @@
     {
       "tag": "v2",
       "new_sqlite_classes": ["LoopCatalog"]
+    },
+    {
+      "tag": "v3",
+      "new_sqlite_classes": ["VoteStore"]
     }
   ],
   "observability": {

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -54,6 +54,7 @@
     "PUBLIC_ORIGIN_URL": "https://calm-mortar-jtek.here.now/",
     "PUBLIC_SHELL_URL": "https://calm-mortar-jtek.here.now/index.html",
     "PUBLIC_SITE_HOSTNAME": "signals.forwardfuture.ai",
-    "PUBLIC_SITE_PATH": "/loop-library"
+    "PUBLIC_SITE_PATH": "/loop-library",
+    "VOTING_UI_ENABLED": "false"
   }
 }


### PR DESCRIPTION
## What changed

- add persistent upvote/downvote storage in a SQLite Durable Object
- require signed GitHub OAuth sessions for vote writes
- keep public vote totals readable and sort featured loops by popularity
- make voting visible but secondary to the primary Copy Loop action
- add the here.now proxy routes, production secret documentation, and regression tests
- remove the unused X OAuth path
- keep voting hidden and disabled until the Worker returns the exact production launch signal

## Why

Loop Library needs durable community ranking without letting anonymous or cross-site requests manipulate votes. GitHub-only authentication keeps the first release focused and matches the configured OAuth application. The fail-closed launch gate lets us prove canonical-domain OAuth cookies and proxy behavior before users see voting.

## Validation

- `node --check site/script.js`
- `node scripts/check.mjs`
- `npm --prefix worker run check` (46 passing tests)
- JSON validation for the site data, proxy manifest, and SEO benchmark
- `git diff --check`
- `npx wrangler deploy --dry-run`
- browser verification with the launch signal missing and explicitly enabled
- autoreview: clean with no actionable findings

## Staged launch

1. Merge with `VOTING_UI_ENABLED=false`.
2. Deploy the Worker first, then publish the site/proxy from the clean deployment checkout under the shared Loop Library lock.
3. While controls remain hidden, verify GitHub start, callback cookies, session persistence, vote persistence, reload, logout, and anonymous rejection on the canonical domain.
4. Change the flag to the exact string `true` on newest integrated `main` and redeploy only the Worker.
5. Verify controls appear, Copy Loop remains primary, and both canonical/backing URLs are healthy.