### PR TITLE
[codex] Make GitHub auth work through the site proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,11 +95,19 @@ npm run deploy
 
 - Public vote totals live in the `VOTE_STORE` SQLite Durable Object. A GitHub
   account may hold at most one vote per loop and can switch or remove it.
-- Vote writes require a valid HMAC-signed, HTTP-only session cookie plus an
-  exact trusted `Origin`. Never accept provider IDs, usernames, or voter keys
-  from browser JSON.
-- Keep OAuth state in short-lived, signed, HTTP-only cookies. Keep post-login
-  redirects on the canonical Loop Library path.
+- The here.now proxy strips browser cookies and mutation `Origin` headers, and
+  it follows upstream redirects. Do not build voting auth around proxied
+  cookies, HTTP redirect responses, or forwarded authorization headers.
+- Start OAuth with a browser-generated nonce held in `sessionStorage`. Bind the
+  nonce and safe return path into a short-lived HMAC-signed OAuth state value.
+  The callback must return a no-store HTML bridge that verifies the stored
+  nonce before saving the signed session token and returning to the canonical
+  Loop Library path.
+- Keep the signed session token in tab-scoped `sessionStorage` and send it only
+  in JSON bodies to the session and vote endpoints. Vote writes must derive the
+  provider ID, username, and voter key exclusively from that verified token.
+  Reject explicit untrusted Origins; missing Origins are expected through the
+  here.now proxy and remain protected by the required bearer token.
 - Do not expose OAuth client secrets or `SESSION_SECRET` in Worker variables,
   browser code, logs, or committed development files. Configure them with:
 
@@ -116,8 +124,9 @@ npm run deploy
   production release. Vote controls render hidden and disabled, then appear
   only when `/api/votes` returns `uiEnabled: true`; missing or malformed values
   must remain fail-closed.
-- With the launch flag off, verify the canonical GitHub start, callback,
-  session, vote persistence, reload, and logout flow. Change the flag to the
+- With the launch flag off, verify the canonical GitHub start, nonce-bound
+  callback bridge, session, vote persistence, reload, and local logout flow.
+  Change the flag to the
   exact string `true` and redeploy the Worker from newest integrated `main`
   only after that smoke test passes. No site republish is required to reveal
   the controls.

--- a/README.md
+++ b/README.md
@@ -302,9 +302,16 @@ secrets; use `worker/.dev.vars.example` for local variable names only. Register
 the canonical callbacks shown in `AGENTS.md`, then deploy the Worker before the
 site shell because the shell calls the new auth and vote routes.
 
+The here.now proxy does not forward browser cookies or mutation Origin headers
+and follows upstream redirects. The OAuth flow therefore uses an HMAC-signed,
+browser-nonce-bound state value and a no-store callback bridge. The bridge saves
+the signed session token in tab-scoped `sessionStorage`; session lookup and vote
+writes send it only inside same-origin JSON request bodies.
+
 The production launch is fail-closed. Keep `VOTING_UI_ENABLED=false` while the
-Worker and proxy are deployed, then complete a GitHub login, session, vote,
-reload, and logout smoke test on the canonical domain. Set the value to the
+Worker and proxy are deployed, then complete a GitHub login, nonce-bound
+callback, session, vote, reload, and logout smoke test on the canonical domain.
+Set the value to the
 exact string `true` and redeploy only the Worker after the smoke test passes;
 the already-published site will reveal voting without another site publish.
 

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -125,15 +125,15 @@ for (const value of [
 assert(html.includes("Search the library"));
 assert(html.includes("Search by title, task, or contributor"));
 assert(html.includes('class="search-field"'));
-assert(html.includes("styles.css?v=20260623-auth-gate"));
-assert(html.includes("script.js?v=20260623-auth-gate"));
+assert(html.includes("styles.css?v=20260623-proxy-auth"));
+assert(html.includes("script.js?v=20260623-proxy-auth"));
 assert(css.includes(".search-control-label"));
 assert(css.includes(".search-control:hover .search-field"));
 assert(css.includes(".search-control:focus-within .search-field"));
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
 for (const page of [learnHtml, agentHtml]) {
-  assert(page.includes("styles.css?v=20260623-auth-gate"));
-  assert(page.includes("script.js?v=20260623-auth-gate"));
+  assert(page.includes("styles.css?v=20260623-proxy-auth"));
+  assert(page.includes("script.js?v=20260623-proxy-auth"));
 }
 for (const page of [html, learnHtml, agentHtml]) {
   const brandPosition = page.indexOf('class="brand-lockup"');
@@ -191,6 +191,13 @@ assert(rendererSource.includes('aria-label="Vote on this loop" hidden'));
 assert(browserScript.includes("setVotingUiVisible(body.uiEnabled === true)"));
 assert(css.includes(".vote-controls[hidden]"));
 assert(authVotesSource.includes('scope: "read:user"'));
+assert(authVotesSource.includes("function authBridge"));
+assert(authVotesSource.includes("readSignedValue(state"));
+assert(browserScript.includes('window.sessionStorage.setItem(OAUTH_NONCE_KEY'));
+assert(browserScript.includes('window.sessionStorage.getItem(VOTE_SESSION_KEY)'));
+assert(browserScript.includes('url.searchParams.set("client_nonce", nonce)'));
+assert(browserScript.includes("sessionToken: readVoteSessionToken()"));
+assert(!authVotesSource.includes("Set-Cookie"));
 assert(!authVotesSource.includes("X_OAUTH"));
 assert(!authVotesSource.includes('"/auth/x"'));
 assert(!browserScript.includes("Continue with X"));

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -76,8 +76,8 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260623-auth-gate" />
-    <script src="../script.js?v=20260623-auth-gate" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260623-proxy-auth" />
+    <script src="../script.js?v=20260623-proxy-auth" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260623-auth-gate" />
+    <link rel="stylesheet" href="./styles.css?v=20260623-proxy-auth" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -198,7 +198,7 @@
   ]
 }
     </script>
-    <script src="./script.js?v=20260623-auth-gate" defer></script>
+    <script src="./script.js?v=20260623-proxy-auth" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -74,8 +74,8 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260623-auth-gate" />
-    <script src="../script.js?v=20260623-auth-gate" defer></script>
+    <link rel="stylesheet" href="../styles.css?v=20260623-proxy-auth" />
+    <script src="../script.js?v=20260623-proxy-auth" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/script.js
+++ b/site/script.js
@@ -606,6 +606,8 @@ const LOOP_LIBRARY_PATH = window.location.pathname === "/loop-library" ||
   ? "/loop-library"
   : "";
 const VOTE_API_URL = `${LOOP_LIBRARY_PATH}/api/votes`;
+const VOTE_SESSION_KEY = "ll_session";
+const OAUTH_NONCE_KEY = "ll_oauth_nonce";
 let voteViewer = null;
 let viewerVotes = {};
 let loginDialog;
@@ -615,6 +617,59 @@ function voteLoginUrl(provider) {
   return `${LOOP_LIBRARY_PATH}/auth/${provider}?${new URLSearchParams({
     return_to: returnTo,
   })}`;
+}
+
+function readVoteSessionToken() {
+  try {
+    return window.sessionStorage.getItem(VOTE_SESSION_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function clearVoteSessionToken() {
+  try {
+    window.sessionStorage.removeItem(VOTE_SESSION_KEY);
+  } catch {
+    // Storage may be unavailable in hardened browser modes.
+  }
+}
+
+function oauthNonce() {
+  const bytes = new Uint8Array(32);
+  window.crypto.getRandomValues(bytes);
+  let binary = "";
+  bytes.forEach((byte) => { binary += String.fromCharCode(byte); });
+  return window.btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+async function beginGithubLogin(link) {
+  const nonce = oauthNonce();
+  try {
+    window.sessionStorage.setItem(OAUTH_NONCE_KEY, nonce);
+    const url = new URL(link.href, window.location.href);
+    url.searchParams.set("client_nonce", nonce);
+    const response = await fetch(url, {
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    });
+    const body = await response.json();
+    if (!response.ok || !body.authorizationUrl) {
+      throw new Error(body.error || "GitHub sign-in is unavailable.");
+    }
+    window.location.assign(body.authorizationUrl);
+  } catch (error) {
+    try {
+      window.sessionStorage.removeItem(OAUTH_NONCE_KEY);
+    } catch {
+      // Storage may be unavailable in hardened browser modes.
+    }
+    link.removeAttribute("aria-disabled");
+    showToast(error.message || "GitHub sign-in is unavailable.");
+  }
 }
 
 function createLoginDialog() {
@@ -644,6 +699,12 @@ function createLoginDialog() {
   githubLink.className = "login-provider login-provider-github";
   githubLink.href = voteLoginUrl("github");
   githubLink.textContent = "Continue with GitHub";
+  githubLink.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (githubLink.getAttribute("aria-disabled") === "true") return;
+    githubLink.setAttribute("aria-disabled", "true");
+    beginGithubLogin(githubLink);
+  });
   providers.append(githubLink);
 
   const cancel = document.createElement("button");
@@ -670,6 +731,11 @@ function showLoginDialog() {
     dialog.setAttribute("open", "");
   }
 }
+
+window.addEventListener("pageshow", () => {
+  loginDialog?.querySelector(".login-provider-github")
+    ?.removeAttribute("aria-disabled");
+});
 
 function updateVoteControls(control, counts = {}, viewerVote = 0) {
   const upvote = control.querySelector('[data-vote-value="1"]');
@@ -721,15 +787,8 @@ function renderVoteAccount() {
   const logout = document.createElement("button");
   logout.type = "button";
   logout.textContent = "Sign out";
-  logout.addEventListener("click", async () => {
-    const response = await fetch(`${LOOP_LIBRARY_PATH}/auth/logout`, {
-      method: "POST",
-      credentials: "same-origin",
-    });
-    if (!response.ok) {
-      showToast("Sign out failed. Try again.");
-      return;
-    }
+  logout.addEventListener("click", () => {
+    clearVoteSessionToken();
     voteViewer = null;
     viewerVotes = {};
     renderVoteAccount();
@@ -753,8 +812,36 @@ async function loadVotes() {
     });
     if (!response.ok) throw new Error("Voting unavailable");
     const body = await response.json();
-    voteViewer = body.viewer || null;
-    viewerVotes = body.viewerVotes || {};
+    voteViewer = null;
+    viewerVotes = {};
+    const sessionToken = readVoteSessionToken();
+    if (sessionToken) {
+      try {
+        const sessionResponse = await fetch(`${LOOP_LIBRARY_PATH}/auth/session`, {
+          method: "POST",
+          credentials: "same-origin",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ sessionToken }),
+        });
+        if (!sessionResponse.ok) {
+          if (sessionResponse.status < 500) clearVoteSessionToken();
+        } else {
+          const sessionBody = await sessionResponse.json();
+          if (sessionBody.viewer) {
+            voteViewer = sessionBody.viewer;
+            viewerVotes = sessionBody.viewerVotes || {};
+          } else {
+            clearVoteSessionToken();
+          }
+        }
+      } catch {
+        // Public totals and the launch gate remain usable when restoring an
+        // existing session is temporarily unavailable.
+      }
+    }
     voteControls.forEach((control) => {
       const slug = control.dataset.loopSlug;
       updateVoteControls(
@@ -797,11 +884,15 @@ voteControls.forEach((control) => {
               Accept: "application/json",
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({ value: nextValue }),
+            body: JSON.stringify({
+              value: nextValue,
+              sessionToken: readVoteSessionToken(),
+            }),
           },
         );
         const body = await response.json();
         if (response.status === 401) {
+          clearVoteSessionToken();
           voteViewer = null;
           viewerVotes = {};
           renderVoteAccount();

--- a/worker/src/auth-votes.js
+++ b/worker/src/auth-votes.js
@@ -1,8 +1,7 @@
-const SESSION_COOKIE = "ll_session";
-const OAUTH_COOKIE = "ll_oauth";
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
 const OAUTH_TTL_SECONDS = 10 * 60;
 const MAX_VOTE_BODY_BYTES = 1024;
+const OAUTH_NONCE_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
 
 export async function handleAuthVoteRoute(
   request,
@@ -26,32 +25,37 @@ export async function handleAuthVoteRoute(
     if (request.method !== "GET") return methodNotAllowed("GET");
     if (!env.VOTE_STORE) return unavailable("Voting is not configured.");
 
-    const viewer = await readSession(request, env);
-    const response = await voteStoreFetch(
-      env,
-      `/votes${viewer ? `?voter=${encodeURIComponent(viewer.sub)}` : ""}`,
-    );
+    const response = await voteStoreFetch(env, "/votes");
     const body = await response.json();
     return jsonResponse({
       ...body,
       uiEnabled: env.VOTING_UI_ENABLED === "true",
-      viewer: publicViewer(viewer),
+      viewer: null,
+      viewerVotes: {},
     });
   }
 
   if (path === "/auth/session") {
-    if (request.method !== "GET") return methodNotAllowed("GET");
-    return jsonResponse({ viewer: publicViewer(await readSession(request, env)) });
+    if (request.method !== "POST") return methodNotAllowed("POST");
+    const body = await readAuthBody(request);
+    if (body instanceof Response) return body;
+    const viewer = await readSession(body.sessionToken, env);
+    if (!viewer) return jsonResponse({ viewer: null, viewerVotes: {} });
+    const response = await voteStoreFetch(
+      env,
+      `/votes?voter=${encodeURIComponent(viewer.sub)}`,
+    );
+    const votes = await response.json();
+    return jsonResponse({
+      viewer: publicViewer(viewer),
+      viewerVotes: votes.viewerVotes || {},
+    });
   }
 
   if (path === "/auth/logout") {
     if (request.method !== "POST") return methodNotAllowed("POST");
     if (!isTrustedMutationOrigin(request, env)) return forbidden();
-    return jsonResponse(
-      { ok: true },
-      200,
-      { "Set-Cookie": clearCookie(SESSION_COOKIE, env) },
-    );
+    return jsonResponse({ ok: true });
   }
 
   if (path === "/auth/github") {
@@ -76,16 +80,15 @@ export async function handleAuthVoteRoute(
       return unavailable("Voting is not configured.");
     }
 
-    const viewer = await readSession(request, env);
+    const vote = await readVoteBody(request);
+    if (vote instanceof Response) return vote;
+    const viewer = await readSession(vote.sessionToken, env);
     if (!viewer) {
       return jsonResponse(
         { error: "Sign in with GitHub to vote.", code: "authentication_required" },
         401,
       );
     }
-
-    const value = await readVoteValue(request);
-    if (value instanceof Response) return value;
 
     const slug = voteMatch[1];
     if (!(await isPublishedLoop(env, slug))) {
@@ -99,7 +102,7 @@ export async function handleAuthVoteRoute(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        value,
+        value: vote.value,
         voterKey: viewer.sub,
         provider: viewer.provider,
         username: viewer.username,
@@ -125,15 +128,22 @@ async function startOAuth(requestUrl, env) {
     return unavailable("Login is not configured.");
   }
 
-  const state = randomUrlSafe(32);
+  const clientNonce = requestUrl.searchParams.get("client_nonce") || "";
+  if (!OAUTH_NONCE_PATTERN.test(clientNonce)) {
+    return jsonResponse(
+      { error: "Invalid OAuth nonce", code: "invalid_oauth_nonce" },
+      400,
+    );
+  }
   const returnTo = safeReturnTo(
     requestUrl.searchParams.get("return_to"),
     env,
   );
-  const oauthCookie = await signedValue(
+  const state = await signedValue(
     {
+      v: 1,
       provider: "github",
-      state,
+      clientNonce,
       returnTo,
       exp: Math.floor(Date.now() / 1000) + OAUTH_TTL_SECONDS,
     },
@@ -148,39 +158,37 @@ async function startOAuth(requestUrl, env) {
     state,
   });
 
-  return redirect(authorizationUrl.toString(), {
-    "Set-Cookie": setCookie(OAUTH_COOKIE, oauthCookie, OAUTH_TTL_SECONDS, env),
-  });
+  return jsonResponse({ authorizationUrl: authorizationUrl.toString() });
 }
 
 async function finishOAuth(request, requestUrl, env, fetcher) {
-  const oauth = await readSignedCookie(request, OAUTH_COOKIE, env.SESSION_SECRET);
+  const state = requestUrl.searchParams.get("state") || "";
+  const oauth = await readSignedValue(state, env.SESSION_SECRET);
   const fallback = safeReturnTo(null, env);
   const returnTo = oauth?.returnTo || fallback;
-  const clearOAuth = clearCookie(OAUTH_COOKIE, env);
 
   if (
     !oauth ||
+    oauth.v !== 1 ||
     oauth.provider !== "github" ||
-    !requestUrl.searchParams.get("state") ||
-    !timingSafeEqual(oauth.state, requestUrl.searchParams.get("state"))
+    !OAUTH_NONCE_PATTERN.test(oauth.clientNonce || "")
   ) {
-    return redirect(authErrorUrl(returnTo, "invalid_state", env), {
-      "Set-Cookie": clearOAuth,
-    });
+    return authBridge(authErrorUrl(returnTo, "invalid_state", env));
   }
 
   if (requestUrl.searchParams.get("error")) {
-    return redirect(authErrorUrl(returnTo, "access_denied", env), {
-      "Set-Cookie": clearOAuth,
-    });
+    return authBridge(
+      authErrorUrl(returnTo, "access_denied", env),
+      { clientNonce: oauth.clientNonce },
+    );
   }
 
   const code = requestUrl.searchParams.get("code");
   if (!code) {
-    return redirect(authErrorUrl(returnTo, "missing_code", env), {
-      "Set-Cookie": clearOAuth,
-    });
+    return authBridge(
+      authErrorUrl(returnTo, "missing_code", env),
+      { clientNonce: oauth.clientNonce },
+    );
   }
 
   try {
@@ -203,25 +211,23 @@ async function finishOAuth(request, requestUrl, env, fetcher) {
       },
       env.SESSION_SECRET,
     );
-    const headers = new Headers({
-      "Cache-Control": "no-store",
-      Location: absoluteReturnTo(returnTo, env),
-      "Referrer-Policy": "no-referrer",
-    });
-    headers.append(
-      "Set-Cookie",
-      setCookie(SESSION_COOKIE, session, SESSION_TTL_SECONDS, env),
+    return authBridge(
+      absoluteReturnTo(returnTo, env),
+      {
+        clientNonce: oauth.clientNonce,
+        sessionToken: session,
+      },
+      authErrorUrl(returnTo, "invalid_state", env),
     );
-    headers.append("Set-Cookie", clearOAuth);
-    return new Response(null, { status: 302, headers });
   } catch (error) {
     console.error("OAuth login failed", {
       provider: "github",
       message: error instanceof Error ? error.message : String(error),
     });
-    return redirect(authErrorUrl(returnTo, "provider_error", env), {
-      "Set-Cookie": clearOAuth,
-    });
+    return authBridge(
+      authErrorUrl(returnTo, "provider_error", env),
+      { clientNonce: oauth.clientNonce },
+    );
   }
 }
 
@@ -271,9 +277,9 @@ function githubConfiguration(env) {
   };
 }
 
-async function readSession(request, env) {
+async function readSession(sessionToken, env) {
   if (!env.SESSION_SECRET) return null;
-  const session = await readSignedCookie(request, SESSION_COOKIE, env.SESSION_SECRET);
+  const session = await readSignedValue(sessionToken, env.SESSION_SECRET);
   if (
     !session ||
     session.v !== 1 ||
@@ -296,7 +302,7 @@ function publicViewer(viewer) {
     : null;
 }
 
-async function readVoteValue(request) {
+async function readVoteBody(request) {
   const length = Number(request.headers.get("Content-Length") || 0);
   if (Number.isFinite(length) && length > MAX_VOTE_BODY_BYTES) {
     return jsonResponse({ error: "Vote is too large", code: "invalid_vote" }, 413);
@@ -307,10 +313,50 @@ async function readVoteValue(request) {
       return jsonResponse({ error: "Vote is too large", code: "invalid_vote" }, 413);
     }
     const body = JSON.parse(text);
-    if (!body || ![-1, 0, 1].includes(body.value)) throw new Error("invalid");
-    return body.value;
+    if (
+      !body ||
+      ![-1, 0, 1].includes(body.value) ||
+      (body.sessionToken !== undefined && typeof body.sessionToken !== "string") ||
+      String(body.sessionToken || "").length > 900
+    ) {
+      throw new Error("invalid");
+    }
+    return { value: body.value, sessionToken: body.sessionToken || "" };
   } catch {
     return jsonResponse({ error: "Invalid vote", code: "invalid_vote" }, 400);
+  }
+}
+
+async function readAuthBody(request) {
+  const length = Number(request.headers.get("Content-Length") || 0);
+  if (Number.isFinite(length) && length > MAX_VOTE_BODY_BYTES) {
+    return jsonResponse(
+      { error: "Session request is too large", code: "invalid_session" },
+      413,
+    );
+  }
+  try {
+    const text = await request.text();
+    if (new TextEncoder().encode(text).byteLength > MAX_VOTE_BODY_BYTES) {
+      return jsonResponse(
+        { error: "Session request is too large", code: "invalid_session" },
+        413,
+      );
+    }
+    const body = JSON.parse(text);
+    if (
+      !body ||
+      typeof body.sessionToken !== "string" ||
+      body.sessionToken.length > 900
+    ) {
+      throw new Error("invalid");
+    }
+    return { sessionToken: body.sessionToken };
+  } catch {
+    return jsonResponse(
+      { error: "Invalid session request", code: "invalid_session" },
+      400,
+    );
   }
 }
 
@@ -329,7 +375,10 @@ function voteStoreFetch(env, path, init) {
 
 function isTrustedMutationOrigin(request, env) {
   const origin = request.headers.get("Origin");
-  if (!origin) return false;
+  // here.now intentionally strips browser Origin headers from proxy requests.
+  // The signed bearer token remains required for every vote; reject only an
+  // explicit, untrusted Origin so direct cross-site requests still fail.
+  if (!origin) return true;
   const allowed = new Set([
     `https://${env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.ai"}`,
     "http://localhost:4173",
@@ -386,35 +435,14 @@ function stripBasePath(pathname, basePath) {
   return pathname;
 }
 
-function setCookie(name, value, maxAge, env) {
-  return `${name}=${value}; Path=${cookiePath(env)}; Max-Age=${maxAge}; HttpOnly; Secure; SameSite=Lax`;
-}
-
-function clearCookie(name, env) {
-  return `${name}=; Path=${cookiePath(env)}; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;
-}
-
-function cookiePath(env) {
-  return `${normalizeBasePath(env.PUBLIC_SITE_PATH || "/loop-library") || "/"}/`.replace("//", "/");
-}
-
-function cookieValue(request, name) {
-  const cookies = request.headers.get("Cookie") || "";
-  for (const part of cookies.split(";")) {
-    const [key, ...rest] = part.trim().split("=");
-    if (key === name) return rest.join("=");
-  }
-  return "";
-}
-
 async function signedValue(payload, secret) {
   const encoded = base64Url(JSON.stringify(payload));
   return `${encoded}.${await hmac(encoded, secret)}`;
 }
 
-async function readSignedCookie(request, name, secret) {
+async function readSignedValue(value, secret) {
   if (!secret) return null;
-  const value = cookieValue(request, name);
+  if (typeof value !== "string" || value.length > 2000) return null;
   const separator = value.lastIndexOf(".");
   if (separator < 1) return null;
   const encoded = value.slice(0, separator);
@@ -477,16 +505,65 @@ function timingSafeEqual(left, right) {
   return different === 0;
 }
 
-function redirect(location, headers = {}) {
-  return new Response(null, {
-    status: 302,
+function authBridge(destination, payload = {}, invalidStateDestination = destination) {
+  const bridge = scriptJson({
+    clientNonce: payload.clientNonce || null,
+    destination,
+    invalidStateDestination,
+    sessionToken: payload.sessionToken || null,
+  });
+  const safeDestination = escapeHtml(destination);
+  const body = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex"><meta name="referrer" content="no-referrer"><title>Finishing GitHub sign-in</title></head>
+<body><p>Finishing GitHub sign-in…</p><p><a href="${safeDestination}">Continue</a></p>
+<script>
+const bridge = ${bridge};
+let destination = bridge.destination;
+try {
+  if (bridge.clientNonce) {
+    const storedNonce = sessionStorage.getItem("ll_oauth_nonce");
+    sessionStorage.removeItem("ll_oauth_nonce");
+    if (bridge.sessionToken && storedNonce === bridge.clientNonce) {
+      sessionStorage.setItem("ll_session", bridge.sessionToken);
+    } else if (bridge.sessionToken) {
+      destination = bridge.invalidStateDestination;
+    }
+  }
+} catch {
+  if (bridge.sessionToken) {
+    destination = bridge.invalidStateDestination;
+  }
+}
+location.replace(destination);
+</script></body></html>`;
+  return new Response(body, {
+    status: 200,
     headers: {
       "Cache-Control": "no-store",
-      Location: location,
+      "Content-Security-Policy": "default-src 'none'; script-src 'unsafe-inline'; style-src 'none'; base-uri 'none'; frame-ancestors 'none'",
+      "Content-Type": "text/html; charset=utf-8",
       "Referrer-Policy": "no-referrer",
-      ...headers,
+      "X-Content-Type-Options": "nosniff",
     },
   });
+}
+
+function scriptJson(value) {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function jsonResponse(body, status = 200, headers = {}) {

--- a/worker/src/render-loops.js
+++ b/worker/src/render-loops.js
@@ -311,9 +311,9 @@ export function renderLoopPage(loop, loops) {
     <link rel="alternate" type="text/plain" title="${SITE.name} plain-text catalog" href="${SITE.baseUrl}catalog.txt" />
     <link rel="help" href="${SITE.baseUrl}agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260623-auth-gate" />
+    <link rel="stylesheet" href="../../styles.css?v=20260623-proxy-auth" />
     <script type="application/ld+json">${jsonForHtml(structuredData)}</script>
-    <script src="../../script.js?v=20260623-auth-gate" defer></script>
+    <script src="../../script.js?v=20260623-proxy-auth" defer></script>
     <title>${escapeHtml(loop.seoTitle)}</title>
   </head>
   <body>

--- a/worker/test/auth-votes.test.js
+++ b/worker/test/auth-votes.test.js
@@ -88,28 +88,20 @@ function makeEnv() {
   };
 }
 
-function cookiePair(setCookie, name) {
-  const match = setCookie.match(new RegExp(`(?:^|, )(${name}=[^;]+)`));
-  assert(match, `${name} cookie missing from ${setCookie}`);
-  return match[1];
-}
-
 async function githubSession(env) {
+  const clientNonce = "test-browser-nonce-that-is-at-least-32-chars";
   const start = await handleAuthVoteRoute(
-    new Request(`${BASE}/auth/github?return_to=%2Floop-library%2Floops%2Fovernight-docs-sweep%2F`),
+    new Request(`${BASE}/auth/github?return_to=%2Floop-library%2Floops%2Fovernight-docs-sweep%2F&client_nonce=${clientNonce}`),
     env,
   );
-  assert.equal(start.status, 302);
-  const authorization = new URL(start.headers.get("Location"));
+  assert.equal(start.status, 200);
+  const authorization = new URL((await start.json()).authorizationUrl);
   assert.equal(authorization.origin, "https://github.com");
   assert.equal(authorization.searchParams.get("scope"), "read:user");
   const state = authorization.searchParams.get("state");
-  const oauthCookie = cookiePair(start.headers.get("Set-Cookie"), "ll_oauth");
   const calls = [];
   const callback = await handleAuthVoteRoute(
-    new Request(`${BASE}/auth/callback/github?code=test-code&state=${state}`, {
-      headers: { Cookie: oauthCookie },
-    }),
+    new Request(`${BASE}/auth/callback/github?code=test-code&state=${encodeURIComponent(state)}`),
     env,
     {
       fetch: async (input, init = {}) => {
@@ -124,32 +116,35 @@ async function githubSession(env) {
       },
     },
   );
-  assert.equal(callback.status, 302);
-  assert.equal(
-    callback.headers.get("Location"),
-    `${BASE}/loops/overnight-docs-sweep/`,
-  );
+  assert.equal(callback.status, 200);
+  const callbackBody = await callback.text();
+  assert.match(callbackBody, /sessionStorage\.setItem\("ll_session"/);
+  assert.match(callbackBody, /loop-library\/loops\/overnight-docs-sweep/);
+  assert.match(callbackBody, new RegExp(clientNonce));
   assert.equal(calls.length, 2);
   assert.equal(
     new Headers(calls[1].init.headers).get("Authorization"),
     "Bearer github-access-token",
   );
-  return cookiePair(callback.headers.get("Set-Cookie"), "ll_session");
+  const sessionMatch = callbackBody.match(
+    /"sessionToken":"([A-Za-z0-9_.-]+)"/,
+  );
+  assert(sessionMatch, "session token missing from OAuth bridge");
+  return sessionMatch[1];
 }
 
 test("GitHub OAuth creates a signed session that can cast, switch, and remove a vote", async () => {
   const env = makeEnv();
-  const sessionCookie = await githubSession(env);
+  const sessionToken = await githubSession(env);
   const voteRequest = (value, origin = ORIGIN) => new Request(
     `${BASE}/api/loops/overnight-docs-sweep/vote`,
     {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Cookie: sessionCookie,
         Origin: origin,
       },
-      body: JSON.stringify({ value }),
+      body: JSON.stringify({ value, sessionToken }),
     },
   );
 
@@ -168,17 +163,26 @@ test("GitHub OAuth creates a signed session that can cast, switch, and remove a 
     score: -1,
   });
 
-  const totals = await handleAuthVoteRoute(
-    new Request(`${BASE}/api/votes`, { headers: { Cookie: sessionCookie } }),
+  const session = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/session`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionToken }),
+    }),
     env,
   );
-  const totalsBody = await totals.json();
-  assert.deepEqual(totalsBody.viewer, {
+  const sessionBody = await session.json();
+  assert.deepEqual(sessionBody.viewer, {
     provider: "github",
     username: "octoloop",
     name: "Octo Loop",
   });
-  assert.equal(totalsBody.viewerVotes["overnight-docs-sweep"], -1);
+  assert.equal(sessionBody.viewerVotes["overnight-docs-sweep"], -1);
+
+  const totals = await handleAuthVoteRoute(new Request(`${BASE}/api/votes`), env);
+  const totalsBody = await totals.json();
+  assert.equal(totalsBody.viewer, null);
+  assert.deepEqual(totalsBody.viewerVotes, {});
   assert.equal(totalsBody.uiEnabled, true);
 
   const removed = await handleAuthVoteRoute(voteRequest(0), env);
@@ -226,16 +230,15 @@ test("vote writes reject anonymous, cross-site, malformed, and unpublished reque
   );
   assert.equal(anonymous.status, 401);
 
-  const sessionCookie = await githubSession(env);
+  const sessionToken = await githubSession(env);
   const crossSite = await handleAuthVoteRoute(
     new Request(`${BASE}/api/loops/overnight-docs-sweep/vote`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Cookie: sessionCookie,
         Origin: "https://phishing.example",
       },
-      body: JSON.stringify({ value: 1 }),
+      body: JSON.stringify({ value: 1, sessionToken }),
     }),
     env,
   );
@@ -246,10 +249,9 @@ test("vote writes reject anonymous, cross-site, malformed, and unpublished reque
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Cookie: sessionCookie,
         Origin: ORIGIN,
       },
-      body: JSON.stringify({ value: 2 }),
+      body: JSON.stringify({ value: 2, sessionToken }),
     }),
     env,
   );
@@ -260,10 +262,9 @@ test("vote writes reject anonymous, cross-site, malformed, and unpublished reque
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Cookie: sessionCookie,
         Origin: ORIGIN,
       },
-      body: JSON.stringify({ value: 1 }),
+      body: JSON.stringify({ value: 1, sessionToken }),
     }),
     env,
   );
@@ -272,19 +273,25 @@ test("vote writes reject anonymous, cross-site, malformed, and unpublished reque
 
 test("GitHub OAuth state is verified and X routes are absent", async () => {
   const env = makeEnv();
+  const clientNonce = "another-browser-nonce-that-is-at-least-32-chars";
   const githubStart = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/github?return_to=%2Floop-library%2F&client_nonce=${clientNonce}`),
+    env,
+  );
+  assert.equal(githubStart.status, 200);
+
+  const invalidCallback = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/callback/github?code=test-code&state=wrong-state`),
+    env,
+  );
+  assert.equal(invalidCallback.status, 200);
+  assert.match(await invalidCallback.text(), /auth_error=invalid_state/);
+
+  const missingNonce = await handleAuthVoteRoute(
     new Request(`${BASE}/auth/github?return_to=%2Floop-library%2F`),
     env,
   );
-
-  const invalidCallback = await handleAuthVoteRoute(
-    new Request(`${BASE}/auth/callback/github?code=test-code&state=wrong-state`, {
-      headers: { Cookie: cookiePair(githubStart.headers.get("Set-Cookie"), "ll_oauth") },
-    }),
-    env,
-  );
-  assert.equal(invalidCallback.status, 302);
-  assert.match(invalidCallback.headers.get("Location"), /auth_error=invalid_state/);
+  assert.equal(missingNonce.status, 400);
 
   assert.equal(
     await handleAuthVoteRoute(new Request(`${BASE}/auth/x`), env),
@@ -292,22 +299,21 @@ test("GitHub OAuth state is verified and X routes are absent", async () => {
   );
 });
 
-test("logout requires a trusted origin and clears the session", async () => {
+test("mutation origins reject explicit cross-site requests and allow stripped proxy origins", async () => {
   const env = makeEnv();
   const rejected = await handleAuthVoteRoute(
-    new Request(`${BASE}/auth/logout`, { method: "POST" }),
+    new Request(`${BASE}/auth/logout`, {
+      method: "POST",
+      headers: { Origin: "https://phishing.example" },
+    }),
     env,
   );
   assert.equal(rejected.status, 403);
 
   const accepted = await handleAuthVoteRoute(
-    new Request(`${BASE}/auth/logout`, {
-      method: "POST",
-      headers: { Origin: ORIGIN },
-    }),
+    new Request(`${BASE}/auth/logout`, { method: "POST" }),
     env,
   );
   assert.equal(accepted.status, 200);
-  assert.match(accepted.headers.get("Set-Cookie"), /ll_session=;/);
-  assert.match(accepted.headers.get("Set-Cookie"), /Max-Age=0/);
+  assert.deepEqual(await accepted.json(), { ok: true });
 });


### PR DESCRIPTION
## What changed

- replace proxy-incompatible auth cookies with HMAC-signed session tokens stored in tab-scoped `sessionStorage`
- bind OAuth state to a browser-generated nonce and safe return path
- return a no-store callback bridge so browser navigation—not the here.now proxy—finishes OAuth
- send session tokens only in same-origin JSON bodies for session lookup and vote writes
- tolerate proxy-stripped Origin headers while still rejecting explicit untrusted origins
- keep the voting launch flag off throughout the repair

## Root cause

Production tracing during the staged deployment showed that the here.now proxy follows upstream redirects and strips Cookie, Origin, and Referer headers. The original cookie/302 OAuth design therefore could not complete through the canonical domain.

## Validation

- 46 Worker tests pass
- `node scripts/check.mjs`
- syntax and JSON validation
- Worker deploy dry-run
- production proxy tracing with voting hidden
- autoreview clean after fixing session-restore and browser-back resilience findings

## Deployment

Deploy the Worker first with `VOTING_UI_ENABLED=false`, republish the complete site artifact for the new cache key, complete the canonical GitHub login/session/vote/reload/logout smoke test, then redeploy only the Worker with the flag explicitly enabled.