### PR TITLE
[codex] Add hidden GitHub auth canary entry

### DIFF
--- a/worker/src/auth-votes.js
+++ b/worker/src/auth-votes.js
@@ -128,7 +128,11 @@ async function startOAuth(requestUrl, env) {
     return unavailable("Login is not configured.");
   }
 
-  const clientNonce = requestUrl.searchParams.get("client_nonce") || "";
+  const requestedNonce = requestUrl.searchParams.get("client_nonce");
+  if (requestedNonce === null) {
+    return oauthStartBridge(requestUrl, env);
+  }
+  const clientNonce = requestedNonce;
   if (!OAUTH_NONCE_PATTERN.test(clientNonce)) {
     return jsonResponse(
       { error: "Invalid OAuth nonce", code: "invalid_oauth_nonce" },
@@ -159,6 +163,54 @@ async function startOAuth(requestUrl, env) {
   });
 
   return jsonResponse({ authorizationUrl: authorizationUrl.toString() });
+}
+
+function oauthStartBridge(requestUrl, env) {
+  const startUrl = new URL(
+    `${canonicalOrigin(env)}${normalizeBasePath(
+      env.PUBLIC_SITE_PATH || "/loop-library",
+    )}/auth/github`,
+  );
+  startUrl.searchParams.set(
+    "return_to",
+    safeReturnTo(requestUrl.searchParams.get("return_to"), env),
+  );
+  const bridge = scriptJson({ startUrl: startUrl.toString() });
+  const body = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex"><meta name="referrer" content="no-referrer"><title>Starting GitHub sign-in</title></head>
+<body><p data-auth-status>Starting GitHub sign-in…</p>
+<script>
+const bridge = ${bridge};
+try {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let binary = "";
+  bytes.forEach((byte) => { binary += String.fromCharCode(byte); });
+  const nonce = btoa(binary).replace(/\\+/g, "-").replace(/\\//g, "_").replace(/=+$/, "");
+  sessionStorage.setItem("ll_oauth_nonce", nonce);
+  const url = new URL(bridge.startUrl);
+  url.searchParams.set("client_nonce", nonce);
+  fetch(url, { headers: { Accept: "application/json" } })
+    .then(async (response) => {
+      const result = await response.json();
+      if (!response.ok || !result.authorizationUrl) throw new Error("GitHub sign-in is unavailable.");
+      location.replace(result.authorizationUrl);
+    })
+    .catch(() => { document.querySelector("[data-auth-status]").textContent = "GitHub sign-in is unavailable. Please try again."; });
+} catch {
+  document.querySelector("[data-auth-status]").textContent = "GitHub sign-in is unavailable in this browser.";
+}
+</script></body></html>`;
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Security-Policy": `default-src 'none'; script-src 'unsafe-inline'; connect-src 'self' ${canonicalOrigin(env)}; base-uri 'none'; frame-ancestors 'none'`,
+      "Content-Type": "text/html; charset=utf-8",
+      "Referrer-Policy": "no-referrer",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
 }
 
 async function finishOAuth(request, requestUrl, env, fetcher) {

--- a/worker/test/auth-votes.test.js
+++ b/worker/test/auth-votes.test.js
@@ -291,7 +291,17 @@ test("GitHub OAuth state is verified and X routes are absent", async () => {
     new Request(`${BASE}/auth/github?return_to=%2Floop-library%2F`),
     env,
   );
-  assert.equal(missingNonce.status, 400);
+  assert.equal(missingNonce.status, 200);
+  const startBridge = await missingNonce.text();
+  assert.match(startBridge, /sessionStorage\.setItem\("ll_oauth_nonce"/);
+  assert.match(startBridge, /client_nonce/);
+  assert.match(startBridge, /GitHub sign-in/);
+
+  const malformedNonce = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/github?client_nonce=too-short`),
+    env,
+  );
+  assert.equal(malformedNonce.status, 400);
 
   assert.equal(
     await handleAuthVoteRoute(new Request(`${BASE}/auth/x`), env),


### PR DESCRIPTION
## What changed

Direct navigation to `/loop-library/auth/github` now returns a no-store browser bridge that generates and stores the OAuth nonce, requests the signed GitHub authorization URL, and continues in the browser. Explicit malformed nonces remain rejected.

## Why

Voting is intentionally hidden during the staged rollout, so the production OAuth smoke test needs a durable entry point that does not require exposing or enabling a vote button.

## Validation

- 46 Worker tests pass
- Worker deploy dry-run passes with `VOTING_UI_ENABLED=false`
- autoreview clean with no actionable findings

This changes only the Worker; the site does not need to be republished.