### PR TITLE
[codex] Use live catalog for vote validation

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -193,6 +193,7 @@ assert(css.includes(".vote-controls[hidden]"));
 assert(authVotesSource.includes('scope: "read:user"'));
 assert(authVotesSource.includes("function authBridge"));
 assert(authVotesSource.includes("readSignedValue(state"));
+assert(authVotesSource.includes('LOOP_CATALOG_INSTANCE = "published-loops"'));
 assert(browserScript.includes('window.sessionStorage.setItem(OAUTH_NONCE_KEY'));
 assert(browserScript.includes('window.sessionStorage.getItem(VOTE_SESSION_KEY)'));
 assert(browserScript.includes('url.searchParams.set("client_nonce", nonce)'));

--- a/worker/src/auth-votes.js
+++ b/worker/src/auth-votes.js
@@ -2,6 +2,7 @@ const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
 const OAUTH_TTL_SECONDS = 10 * 60;
 const MAX_VOTE_BODY_BYTES = 1024;
 const OAUTH_NONCE_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
+const LOOP_CATALOG_INSTANCE = "published-loops";
 
 export async function handleAuthVoteRoute(
   request,
@@ -413,7 +414,7 @@ async function readAuthBody(request) {
 }
 
 async function isPublishedLoop(env, slug) {
-  const id = env.LOOP_CATALOG.idFromName("production");
+  const id = env.LOOP_CATALOG.idFromName(LOOP_CATALOG_INSTANCE);
   const response = await env.LOOP_CATALOG.get(id).fetch("https://loop-catalog/published");
   if (!response.ok) return false;
   const catalog = await response.json();

--- a/worker/test/auth-votes.test.js
+++ b/worker/test/auth-votes.test.js
@@ -61,6 +61,7 @@ class MemoryVoteNamespace {
 
 class MemoryCatalogNamespace {
   idFromName(name) {
+    assert.equal(name, "published-loops");
     return name;
   }
 


### PR DESCRIPTION
## What changed

Vote validation now reads the same `published-loops` Durable Object instance used by the public catalog routes. The test namespace asserts the exact instance name, and the repository check guards the invariant.

## Root cause

The first production vote reached the Worker successfully but returned `Loop not found`. Auth voting used a different Durable Object instance name (`production`) from the catalog renderer (`published-loops`), so it saw an empty catalog.

## Validation

- 46 Worker tests pass
- Worker deploy dry-run passes with voting hidden
- autoreview clean
- live catalog confirms the smoke-test slug is published

Voting was switched back off before this repair was prepared.