### PR TITLE
[codex] Persist verified voting launch state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,16 +120,15 @@ npm run deploy
 
 - Register this exact provider callback:
   `https://signals.forwardfuture.ai/loop-library/auth/callback/github`.
-- Keep `VOTING_UI_ENABLED` set to the exact string `false` for the first
-  production release. Vote controls render hidden and disabled, then appear
-  only when `/api/votes` returns `uiEnabled: true`; missing or malformed values
-  must remain fail-closed.
-- With the launch flag off, verify the canonical GitHub start, nonce-bound
+- For auth or proxy changes, set `VOTING_UI_ENABLED` to the exact string
+  `false` for the staged production release. Vote controls render hidden and
+  disabled, then appear only when `/api/votes` returns `uiEnabled: true`;
+  missing or malformed values must remain fail-closed.
+- With the staged flag off, verify the canonical GitHub start, nonce-bound
   callback bridge, session, vote persistence, reload, and local logout flow.
-  Change the flag to the
-  exact string `true` and redeploy the Worker from newest integrated `main`
-  only after that smoke test passes. No site republish is required to reveal
-  the controls.
+  Commit the flag as the exact string `true` and redeploy the Worker from newest
+  integrated `main` only after that smoke test passes. No site republish is
+  required to reveal the controls.
 - Deploy and verify the Worker before publishing a shell or proxy manifest that
   exposes voting or auth routes.
 

--- a/README.md
+++ b/README.md
@@ -308,12 +308,12 @@ browser-nonce-bound state value and a no-store callback bridge. The bridge saves
 the signed session token in tab-scoped `sessionStorage`; session lookup and vote
 writes send it only inside same-origin JSON request bodies.
 
-The production launch is fail-closed. Keep `VOTING_UI_ENABLED=false` while the
-Worker and proxy are deployed, then complete a GitHub login, nonce-bound
-callback, session, vote, reload, and logout smoke test on the canonical domain.
-Set the value to the
-exact string `true` and redeploy only the Worker after the smoke test passes;
-the already-published site will reveal voting without another site publish.
+Auth and proxy changes use a fail-closed staged rollout. Temporarily set
+`VOTING_UI_ENABLED=false` while the Worker and proxy are deployed, then complete
+a GitHub login, nonce-bound callback, session, vote, reload, and logout smoke
+test on the canonical domain. Commit the value as the exact string `true` and
+redeploy only the Worker after the smoke test passes; the already-published site
+will reveal voting without another site publish.
 
 Read [AGENTS.md](AGENTS.md) before editing loops or publishing the site. It
 contains the source-of-truth rules for database publishing, generated

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -246,7 +246,7 @@ assert.equal(wrangler.vars.PUBLIC_ORIGIN_URL, "https://calm-mortar-jtek.here.now
 assert.equal(wrangler.vars.PUBLIC_SHELL_URL, "https://calm-mortar-jtek.here.now/index.html");
 assert.equal(wrangler.vars.PUBLIC_SITE_HOSTNAME, "signals.forwardfuture.ai");
 assert.equal(wrangler.vars.PUBLIC_SITE_PATH, "/loop-library");
-assert.equal(wrangler.vars.VOTING_UI_ENABLED, "false");
+assert.equal(wrangler.vars.VOTING_UI_ENABLED, "true");
 assert.deepEqual(Object.keys(proxyManifest.proxies).sort(), [
   "/",
   "/api/loops",

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -55,6 +55,6 @@
     "PUBLIC_SHELL_URL": "https://calm-mortar-jtek.here.now/index.html",
     "PUBLIC_SITE_HOSTNAME": "signals.forwardfuture.ai",
     "PUBLIC_SITE_PATH": "/loop-library",
-    "VOTING_UI_ENABLED": "false"
+    "VOTING_UI_ENABLED": "true"
   }
 }


### PR DESCRIPTION
## What changed

- persist `VOTING_UI_ENABLED=true` in Worker configuration
- update deployment checks and documentation to stage future auth/proxy changes with the flag off, then commit it on after production verification

## Why

The complete production OAuth, vote persistence, cleanup, and logout smoke test passed. Persisting the verified state prevents a future normal Worker deploy from reverting the one-off runtime override and silently hiding voting.

## Validation

- 46 Worker tests pass
- Worker dry-run reports `VOTING_UI_ENABLED=true`
- canonical login, authenticated vote, reload persistence, vote removal, logout, anonymous rejection, catalog, sitemap, and both canonical/backing site health passed in production