### PR TITLE
[codex] Fix loop row background alignment

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -125,14 +125,16 @@ for (const value of [
 assert(html.includes("Search the library"));
 assert(html.includes("Search by title, task, or contributor"));
 assert(html.includes('class="search-field"'));
-assert(html.includes("styles.css?v=20260623-proxy-auth"));
+assert(html.includes("styles.css?v=20260623-row-background"));
 assert(html.includes("script.js?v=20260623-proxy-auth"));
 assert(css.includes(".search-control-label"));
 assert(css.includes(".search-control:hover .search-field"));
 assert(css.includes(".search-control:focus-within .search-field"));
+assert.match(css, /\.loop-row\s*\{[^}]*background:\s*var\(--surface\);[^}]*\}/);
+assert.match(css, /\.loop-table td\s*\{[^}]*background:\s*transparent;[^}]*\}/);
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
 for (const page of [learnHtml, agentHtml]) {
-  assert(page.includes("styles.css?v=20260623-proxy-auth"));
+  assert(page.includes("styles.css?v=20260623-row-background"));
   assert(page.includes("script.js?v=20260623-proxy-auth"));
 }
 for (const page of [html, learnHtml, agentHtml]) {

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -76,7 +76,7 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260623-proxy-auth" />
+    <link rel="stylesheet" href="../styles.css?v=20260623-row-background" />
     <script src="../script.js?v=20260623-proxy-auth" defer></script>
     <script type="application/ld+json">
       {

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260623-proxy-auth" />
+    <link rel="stylesheet" href="./styles.css?v=20260623-row-background" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -74,7 +74,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260623-proxy-auth" />
+    <link rel="stylesheet" href="../styles.css?v=20260623-row-background" />
     <script src="../script.js?v=20260623-proxy-auth" defer></script>
     <script type="application/ld+json">
       {

--- a/site/styles.css
+++ b/site/styles.css
@@ -829,10 +829,14 @@ code {
   width: 124px;
 }
 
+.loop-row {
+  background: var(--surface);
+}
+
 .loop-table td {
   padding: 22px 20px;
   border: 0;
-  background: var(--surface);
+  background: transparent;
   vertical-align: top;
 }
 

--- a/worker/src/render-loops.js
+++ b/worker/src/render-loops.js
@@ -311,7 +311,7 @@ export function renderLoopPage(loop, loops) {
     <link rel="alternate" type="text/plain" title="${SITE.name} plain-text catalog" href="${SITE.baseUrl}catalog.txt" />
     <link rel="help" href="${SITE.baseUrl}agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260623-proxy-auth" />
+    <link rel="stylesheet" href="../../styles.css?v=20260623-row-background" />
     <script type="application/ld+json">${jsonForHtml(structuredData)}</script>
     <script src="../../script.js?v=20260623-proxy-auth" defer></script>
     <title>${escapeHtml(loop.seoTitle)}</title>


### PR DESCRIPTION
## What changed

- apply each loop card background to the full table row instead of its individual cells
- keep the content and action cells transparent so the card ends on one clean horizontal edge
- refresh the stylesheet cache key across static and Worker-rendered pages
- add CSS contract checks for the row/cell background ownership

## Why

The two table cells can have different content heights. Giving each cell its own background made the bottom edge look cut off horizontally when the text column was taller than the action column.

## Validation

- `node scripts/check.mjs`
- `npm --prefix worker run check` (46 tests)
- `git diff --check`
- structured autoreview: clean, no actionable findings
- local browser verification in light and dark themes