### PR TITLE
[codex] Refresh loop row stylesheet cache

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -125,7 +125,7 @@ for (const value of [
 assert(html.includes("Search the library"));
 assert(html.includes("Search by title, task, or contributor"));
 assert(html.includes('class="search-field"'));
-assert(html.includes("styles.css?v=20260623-row-background"));
+assert(html.includes("styles.css?v=20260623-row-background-v2"));
 assert(html.includes("script.js?v=20260623-proxy-auth"));
 assert(css.includes(".search-control-label"));
 assert(css.includes(".search-control:hover .search-field"));
@@ -134,7 +134,7 @@ assert.match(css, /\.loop-row\s*\{[^}]*background:\s*var\(--surface\);[^}]*\}/);
 assert.match(css, /\.loop-table td\s*\{[^}]*background:\s*transparent;[^}]*\}/);
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
 for (const page of [learnHtml, agentHtml]) {
-  assert(page.includes("styles.css?v=20260623-row-background"));
+  assert(page.includes("styles.css?v=20260623-row-background-v2"));
   assert(page.includes("script.js?v=20260623-proxy-auth"));
 }
 for (const page of [html, learnHtml, agentHtml]) {

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -76,7 +76,7 @@
       href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260623-row-background" />
+    <link rel="stylesheet" href="../styles.css?v=20260623-row-background-v2" />
     <script src="../script.js?v=20260623-proxy-auth" defer></script>
     <script type="application/ld+json">
       {

--- a/site/index.html
+++ b/site/index.html
@@ -132,7 +132,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <link rel="stylesheet" href="./styles.css?v=20260623-row-background" />
+    <link rel="stylesheet" href="./styles.css?v=20260623-row-background-v2" />
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -74,7 +74,7 @@
       href="https://signals.forwardfuture.ai/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
-    <link rel="stylesheet" href="../styles.css?v=20260623-row-background" />
+    <link rel="stylesheet" href="../styles.css?v=20260623-row-background-v2" />
     <script src="../script.js?v=20260623-proxy-auth" defer></script>
     <script type="application/ld+json">
       {

--- a/worker/src/render-loops.js
+++ b/worker/src/render-loops.js
@@ -311,7 +311,7 @@ export function renderLoopPage(loop, loops) {
     <link rel="alternate" type="text/plain" title="${SITE.name} plain-text catalog" href="${SITE.baseUrl}catalog.txt" />
     <link rel="help" href="${SITE.baseUrl}agents/" />
     <link rel="icon" type="image/png" href="../../assets/favicon.png" />
-    <link rel="stylesheet" href="../../styles.css?v=20260623-row-background" />
+    <link rel="stylesheet" href="../../styles.css?v=20260623-row-background-v2" />
     <script type="application/ld+json">${jsonForHtml(structuredData)}</script>
     <script src="../../script.js?v=20260623-proxy-auth" defer></script>
     <title>${escapeHtml(loop.seoTitle)}</title>


### PR DESCRIPTION
## What changed

- advance the stylesheet cache-busting token across static and Worker-rendered pages
- keep the validator aligned with the new asset URL

## Why

Production had the corrected CSS, but an existing browser session retained the prior stylesheet response under the first cache-buster URL. A fresh URL guarantees the row-background rules are fetched instead of using that stale cached response.

## Validation

- `node scripts/check.mjs`
- `npm --prefix worker run check` (46 tests)
- `git diff --check`
- structured autoreview: clean, no actionable findings