### PR TITLE
[codex] migrate Loop Library to forwardfuture.com

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@
   duplicate.
 
 Create the Cloudflare Turnstile widget in Managed mode and allow both
-`signals.forwardfuture.ai` and the current backing `*.here.now` hostname. Keep
+`signals.forwardfuture.com` and the current backing `*.here.now` hostname. Keep
 the site's Turnstile appearance set to `interaction-only` so most visitors do
 not see a challenge.
 
@@ -89,7 +89,7 @@ npm run deploy
 ```
 
 `TURNSTILE_HOSTNAMES` is a comma-separated exact allowlist containing
-`signals.forwardfuture.ai` and the current backing `*.here.now` hostname.
+`signals.forwardfuture.com` and the current backing `*.here.now` hostname.
 
 ## Authenticated voting
 
@@ -119,7 +119,7 @@ npm run deploy
   ```
 
 - Register this exact provider callback:
-  `https://signals.forwardfuture.ai/loop-library/auth/callback/github`.
+  `https://signals.forwardfuture.com/loop-library/auth/callback/github`.
 - For auth or proxy changes, set `VOTING_UI_ENABLED` to the exact string
   `false` for the staged production release. Vote controls render hidden and
   disabled, then appear only when `/api/votes` returns `uiEnabled: true`;
@@ -179,6 +179,6 @@ curl -sS "https://here.now/api/v1/publishes/{slug}/data/weekly_signups?limit=50"
   database content and the backing here.now Site for the static shell before
   reporting success.
 - After a production content deployment, submit
-  `https://signals.forwardfuture.ai/loop-library/sitemap.xml` in Google Search
+  `https://signals.forwardfuture.com/loop-library/sitemap.xml` in Google Search
   Console and Bing Webmaster Tools. Verify that the custom domain's root
   `robots.txt` still allows Googlebot, Bingbot, and `OAI-SearchBot`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Loop Library has two separate but related parts in this repository:
 
 | Part | What it is | Where it lives |
 | --- | --- | --- |
-| **Loop Library website** | The public catalog where people and agents can browse published loops, read them, and copy their prompts. No installation is required. | [Live website](https://signals.forwardfuture.ai/loop-library/) · shell in [`site/`](site/), database and rendering in [`worker/`](worker/) |
+| **Loop Library website** | The public catalog where people and agents can browse published loops, read them, and copy their prompts. No installation is required. | [Live website](https://signals.forwardfuture.com/loop-library/) · shell in [`site/`](site/), database and rendering in [`worker/`](worker/) |
 | **Loop Library skill** | An optional installable guide that helps an AI agent discover, find, audit, repair, adapt, or design loops through conversation. It uses the website's live catalog when recommending published loops. | source in [`skills/loop-library/`](skills/loop-library/) |
 
 The website is the library; the skill is a companion way to work with it. You
@@ -12,10 +12,10 @@ can browse or give an agent the website without installing the skill. Installing
 the skill adds the guided workflow, but it does not install or host the website.
 
 Agents that do not have the skill can use the published
-[agent guide](https://signals.forwardfuture.ai/loop-library/agents/),
-[agent instructions](https://signals.forwardfuture.ai/loop-library/llms.txt),
-[JSON catalog](https://signals.forwardfuture.ai/loop-library/catalog.json), or
-[plain-text catalog](https://signals.forwardfuture.ai/loop-library/catalog.txt)
+[agent guide](https://signals.forwardfuture.com/loop-library/agents/),
+[agent instructions](https://signals.forwardfuture.com/loop-library/llms.txt),
+[JSON catalog](https://signals.forwardfuture.com/loop-library/catalog.json), or
+[plain-text catalog](https://signals.forwardfuture.com/loop-library/catalog.txt)
 directly.
 
 Each published loop tells an agent what to do, how to check its work, what to
@@ -206,11 +206,11 @@ Every published loop also includes a few useful parts:
 
 ## Explore or contribute
 
-Visit the [Loop Library](https://signals.forwardfuture.ai/loop-library/) to
+Visit the [Loop Library](https://signals.forwardfuture.com/loop-library/) to
 browse published loops, copy one into your own workflow, or submit a loop that
 has worked well for you.
 
-Loop Library is a [Forward Future](https://www.forwardfuture.ai/) project and is
+Loop Library is a [Forward Future](https://www.forwardfuture.com/) project and is
 available under the [MIT License](LICENSE).
 
 <details>

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -115,9 +115,9 @@ for (const value of [
   'id="loop-sort"',
   'id="library-pagination"',
   'name="loop-library-form-api"',
-  "https://signals.forwardfuture.ai/loop-library/catalog.json",
-  "https://signals.forwardfuture.ai/loop-library/sitemap.xml",
-  "https://signals.forwardfuture.ai/loop-library/feed.xml",
+  "https://signals.forwardfuture.com/loop-library/catalog.json",
+  "https://signals.forwardfuture.com/loop-library/sitemap.xml",
+  "https://signals.forwardfuture.com/loop-library/feed.xml",
   "https://here.now/r/signals",
 ]) {
   assert(html.includes(value), value);
@@ -246,9 +246,9 @@ assert.match(wrangler.vars.BOOTSTRAP_CATALOG_DIGEST, /^[a-f0-9]{64}$/);
 assert.equal(wrangler.vars.BOOTSTRAP_LOOP_COUNT, "50");
 assert.equal(wrangler.vars.PUBLIC_ORIGIN_URL, "https://calm-mortar-jtek.here.now/");
 assert.equal(wrangler.vars.PUBLIC_SHELL_URL, "https://calm-mortar-jtek.here.now/index.html");
-assert.equal(wrangler.vars.PUBLIC_SITE_HOSTNAME, "signals.forwardfuture.ai");
+assert.equal(wrangler.vars.PUBLIC_SITE_HOSTNAME, "signals.forwardfuture.com");
 assert.equal(wrangler.vars.PUBLIC_SITE_PATH, "/loop-library");
-assert.equal(wrangler.vars.VOTING_UI_ENABLED, "true");
+assert.equal(wrangler.vars.VOTING_UI_ENABLED, "false");
 assert.deepEqual(Object.keys(proxyManifest.proxies).sort(), [
   "/",
   "/api/loops",

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -42,38 +42,38 @@
     />
     <meta
       property="og:url"
-      content="https://signals.forwardfuture.ai/loop-library/agents/"
+      content="https://signals.forwardfuture.com/loop-library/agents/"
     />
     <meta
       property="og:image"
-      content="https://signals.forwardfuture.ai/loop-library/assets/ff-mark.png"
+      content="https://signals.forwardfuture.com/loop-library/assets/ff-mark.png"
     />
     <link
       rel="canonical"
-      href="https://signals.forwardfuture.ai/loop-library/agents/"
+      href="https://signals.forwardfuture.com/loop-library/agents/"
     />
     <link
       rel="sitemap"
       type="application/xml"
-      href="https://signals.forwardfuture.ai/loop-library/sitemap.xml"
+      href="https://signals.forwardfuture.com/loop-library/sitemap.xml"
     />
     <link
       rel="alternate"
       type="application/json"
       title="Loop Library catalog"
-      href="https://signals.forwardfuture.ai/loop-library/catalog.json"
+      href="https://signals.forwardfuture.com/loop-library/catalog.json"
     />
     <link
       rel="alternate"
       type="text/plain"
       title="Loop Library agent instructions"
-      href="https://signals.forwardfuture.ai/loop-library/llms.txt"
+      href="https://signals.forwardfuture.com/loop-library/llms.txt"
     />
     <link
       rel="alternate"
       type="text/plain"
       title="Loop Library plain-text catalog"
-      href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
+      href="https://signals.forwardfuture.com/loop-library/catalog.txt"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260623-row-background-v2" />
@@ -84,11 +84,11 @@
         "@type": "TechArticle",
         "headline": "Loop Library Agent Guide",
         "description": "Agent instructions for discovering, selecting, adapting, and safely running published Loop Library workflows.",
-        "url": "https://signals.forwardfuture.ai/loop-library/agents/",
+        "url": "https://signals.forwardfuture.com/loop-library/agents/",
         "publisher": {
           "@type": "Organization",
           "name": "Forward Future",
-          "url": "https://forwardfuture.ai/"
+          "url": "https://forwardfuture.com/"
         }
       }
     </script>
@@ -203,7 +203,7 @@
             </button>
           </div>
           <p data-prompt>
-            Read https://signals.forwardfuture.ai/loop-library/llms.txt, then use
+            Read https://signals.forwardfuture.com/loop-library/llms.txt, then use
             the live catalog to find the best published loop for my goal. Match
             on available inputs, tools, verification, authority, and stopping
             condition. Do not execute a loop until I ask. Never invent missing
@@ -272,7 +272,7 @@
         <div class="footer-actions">
           <p>
             <a href="../">Loop Library</a>
-            <a href="https://forwardfuture.ai/" rel="noopener">forwardfuture.ai</a>
+            <a href="https://forwardfuture.com/" rel="noopener">forwardfuture.com</a>
             <span>&copy; 2026</span>
           </p>
           <a

--- a/site/index.html
+++ b/site/index.html
@@ -54,15 +54,15 @@
     />
     <meta
       property="og:url"
-      content="https://signals.forwardfuture.ai/loop-library/"
+      content="https://signals.forwardfuture.com/loop-library/"
     />
     <meta
       property="og:image"
-      content="https://signals.forwardfuture.ai/loop-library/assets/social/loop-library-20260621-2.png"
+      content="https://signals.forwardfuture.com/loop-library/assets/social/loop-library-20260621-2.png"
     />
     <meta
       property="og:image:secure_url"
-      content="https://signals.forwardfuture.ai/loop-library/assets/social/loop-library-20260621-2.png"
+      content="https://signals.forwardfuture.com/loop-library/assets/social/loop-library-20260621-2.png"
     />
     <meta property="og:image:type" content="image/png" />
     <meta
@@ -82,7 +82,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://signals.forwardfuture.ai/loop-library/assets/social/loop-library-20260621-2.png"
+      content="https://signals.forwardfuture.com/loop-library/assets/social/loop-library-20260621-2.png"
     />
     <meta
       name="twitter:image:alt"
@@ -90,46 +90,46 @@
     />
     <link
       rel="canonical"
-      href="https://signals.forwardfuture.ai/loop-library/"
+      href="https://signals.forwardfuture.com/loop-library/"
     />
     <link
       rel="sitemap"
       type="application/xml"
-      href="https://signals.forwardfuture.ai/loop-library/sitemap.xml"
+      href="https://signals.forwardfuture.com/loop-library/sitemap.xml"
     />
     <link
       rel="alternate"
       type="application/atom+xml"
       title="Loop Library updates"
-      href="https://signals.forwardfuture.ai/loop-library/feed.xml"
+      href="https://signals.forwardfuture.com/loop-library/feed.xml"
     />
     <link
       rel="alternate"
       type="application/json"
       title="Loop Library catalog"
-      href="https://signals.forwardfuture.ai/loop-library/catalog.json"
+      href="https://signals.forwardfuture.com/loop-library/catalog.json"
     />
     <link
       rel="alternate"
       type="text/markdown"
       title="Loop Library catalog in Markdown"
-      href="https://signals.forwardfuture.ai/loop-library/catalog.md"
+      href="https://signals.forwardfuture.com/loop-library/catalog.md"
     />
     <link
       rel="alternate"
       type="text/plain"
       title="Loop Library agent instructions"
-      href="https://signals.forwardfuture.ai/loop-library/llms.txt"
+      href="https://signals.forwardfuture.com/loop-library/llms.txt"
     />
     <link
       rel="alternate"
       type="text/plain"
       title="Loop Library plain-text catalog"
-      href="https://signals.forwardfuture.ai/loop-library/catalog.txt"
+      href="https://signals.forwardfuture.com/loop-library/catalog.txt"
     />
     <link
       rel="help"
-      href="https://signals.forwardfuture.ai/loop-library/agents/"
+      href="https://signals.forwardfuture.com/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
     <link rel="stylesheet" href="./styles.css?v=20260623-row-background-v2" />
@@ -139,44 +139,44 @@
   "@graph": [
     {
       "@type": "Organization",
-      "@id": "https://signals.forwardfuture.ai/loop-library/#organization",
+      "@id": "https://signals.forwardfuture.com/loop-library/#organization",
       "name": "Forward Future",
-      "url": "https://forwardfuture.ai/",
+      "url": "https://forwardfuture.com/",
       "logo": {
         "@type": "ImageObject",
-        "url": "https://signals.forwardfuture.ai/loop-library/assets/ff-mark.png",
+        "url": "https://signals.forwardfuture.com/loop-library/assets/ff-mark.png",
         "width": 1920,
         "height": 1920
       }
     },
     {
       "@type": "WebSite",
-      "@id": "https://signals.forwardfuture.ai/loop-library/#website",
-      "url": "https://signals.forwardfuture.ai/loop-library/",
+      "@id": "https://signals.forwardfuture.com/loop-library/#website",
+      "url": "https://signals.forwardfuture.com/loop-library/",
       "name": "Loop Library",
       "description": "Practical AI agent workflows for engineering, research, editorial work, evaluation, and operations.",
       "publisher": {
-        "@id": "https://signals.forwardfuture.ai/loop-library/#organization"
+        "@id": "https://signals.forwardfuture.com/loop-library/#organization"
       }
     },
     {
       "@type": "CollectionPage",
-      "@id": "https://signals.forwardfuture.ai/loop-library/#collection",
-      "url": "https://signals.forwardfuture.ai/loop-library/",
+      "@id": "https://signals.forwardfuture.com/loop-library/#collection",
+      "url": "https://signals.forwardfuture.com/loop-library/",
       "name": "Loop Library",
       "description": "A practical library of repeatable AI agent workflows with clear checks and stopping conditions.",
       "dateModified": "2026-06-21",
       "primaryImageOfPage": {
         "@type": "ImageObject",
-        "url": "https://signals.forwardfuture.ai/loop-library/assets/social/loop-library-20260621-2.png",
+        "url": "https://signals.forwardfuture.com/loop-library/assets/social/loop-library-20260621-2.png",
         "width": 1200,
         "height": 630
       },
       "isPartOf": {
-        "@id": "https://signals.forwardfuture.ai/loop-library/#website"
+        "@id": "https://signals.forwardfuture.com/loop-library/#website"
       },
       "about": {
-        "@id": "https://signals.forwardfuture.ai/loop-library/#ai-agent-loop"
+        "@id": "https://signals.forwardfuture.com/loop-library/#ai-agent-loop"
       },
       "mainEntity": {
         "@type": "ItemList",
@@ -186,10 +186,10 @@
     },
     {
       "@type": "DefinedTerm",
-      "@id": "https://signals.forwardfuture.ai/loop-library/#ai-agent-loop",
+      "@id": "https://signals.forwardfuture.com/loop-library/#ai-agent-loop",
       "name": "AI agent loop",
       "description": "A repeatable workflow in which an AI agent acts on a goal, checks the result, and continues until it reaches an explicit success or stop condition.",
-      "url": "https://signals.forwardfuture.ai/loop-library/learn/",
+      "url": "https://signals.forwardfuture.com/loop-library/learn/",
       "sameAs": [
         "https://code.claude.com/docs/en/agent-sdk/agent-loop",
         "https://arxiv.org/abs/2210.03629"
@@ -298,7 +298,7 @@
                 type="button"
                 data-copy-social-post
                 data-post-text="Find Loops and create your own - Loop Library"
-                data-post-url="https://signals.forwardfuture.ai/loop-library/"
+                data-post-url="https://signals.forwardfuture.com/loop-library/"
                 aria-label="Copy a Loop Library social post"
               >
                 <svg class="share-copy-icon" viewBox="0 0 24 24" aria-hidden="true">
@@ -673,7 +673,7 @@
         <p><strong>Forward Future</strong> <span>Make the future legible.</span></p>
         <div class="footer-actions">
           <p>
-            <a href="https://forwardfuture.ai/" rel="noopener">forwardfuture.ai</a>
+            <a href="https://forwardfuture.com/" rel="noopener">forwardfuture.com</a>
             <span>&copy; 2026</span>
           </p>
           <a

--- a/site/learn/index.html
+++ b/site/learn/index.html
@@ -42,36 +42,36 @@
     />
     <meta
       property="og:url"
-      content="https://signals.forwardfuture.ai/loop-library/learn/"
+      content="https://signals.forwardfuture.com/loop-library/learn/"
     />
     <meta
       property="og:image"
-      content="https://signals.forwardfuture.ai/loop-library/assets/ff-mark.png"
+      content="https://signals.forwardfuture.com/loop-library/assets/ff-mark.png"
     />
     <link
       rel="canonical"
-      href="https://signals.forwardfuture.ai/loop-library/learn/"
+      href="https://signals.forwardfuture.com/loop-library/learn/"
     />
     <link
       rel="sitemap"
       type="application/xml"
-      href="https://signals.forwardfuture.ai/loop-library/sitemap.xml"
+      href="https://signals.forwardfuture.com/loop-library/sitemap.xml"
     />
     <link
       rel="alternate"
       type="application/json"
       title="Loop Library catalog"
-      href="https://signals.forwardfuture.ai/loop-library/catalog.json"
+      href="https://signals.forwardfuture.com/loop-library/catalog.json"
     />
     <link
       rel="alternate"
       type="text/plain"
       title="Loop Library agent instructions"
-      href="https://signals.forwardfuture.ai/loop-library/llms.txt"
+      href="https://signals.forwardfuture.com/loop-library/llms.txt"
     />
     <link
       rel="help"
-      href="https://signals.forwardfuture.ai/loop-library/agents/"
+      href="https://signals.forwardfuture.com/loop-library/agents/"
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260623-row-background-v2" />
@@ -82,11 +82,11 @@
         "@type": "TechArticle",
         "headline": "How Agent Loops Work",
         "description": "A plain-language guide to writing and running useful agent loops.",
-        "url": "https://signals.forwardfuture.ai/loop-library/learn/",
+        "url": "https://signals.forwardfuture.com/loop-library/learn/",
         "publisher": {
           "@type": "Organization",
           "name": "Forward Future",
-          "url": "https://forwardfuture.ai/"
+          "url": "https://forwardfuture.com/"
         }
       }
     </script>
@@ -413,7 +413,7 @@
         <p><strong>Forward Future</strong> <span>Make the future legible.</span></p>
         <div class="footer-actions">
           <p>
-            <a href="https://forwardfuture.ai/" rel="noopener">forwardfuture.ai</a>
+            <a href="https://forwardfuture.com/" rel="noopener">forwardfuture.com</a>
             <span>&copy; 2026</span>
           </p>
           <a

--- a/skills/loop-library/SKILL.md
+++ b/skills/loop-library/SKILL.md
@@ -50,8 +50,8 @@ feedback-cycle rules below before recommending or crafting it.
 ## Find a published loop
 
 1. When web access is available, read the live
-   [catalog.md](https://signals.forwardfuture.ai/loop-library/catalog.md).
-   Use [catalog.json](https://signals.forwardfuture.ai/loop-library/catalog.json)
+   [catalog.md](https://signals.forwardfuture.com/loop-library/catalog.md).
+   Use [catalog.json](https://signals.forwardfuture.com/loop-library/catalog.json)
    instead when a tool can ingest structured data. The live catalog is the
    source of truth for which loops are published.
 2. If the live catalog is unavailable, say that published-loop discovery is

--- a/worker/bin/publish-loop.mjs
+++ b/worker/bin/publish-loop.mjs
@@ -62,4 +62,4 @@ if (!response.ok) {
 }
 
 const verb = status === "published" ? "Published" : status === "draft" ? "Saved draft" : "Archived";
-console.log(`${verb}: https://signals.forwardfuture.ai/loop-library/loops/${loop.slug}/`);
+console.log(`${verb}: https://signals.forwardfuture.com/loop-library/loops/${loop.slug}/`);

--- a/worker/src/auth-votes.js
+++ b/worker/src/auth-votes.js
@@ -433,7 +433,7 @@ function isTrustedMutationOrigin(request, env) {
   // explicit, untrusted Origin so direct cross-site requests still fail.
   if (!origin) return true;
   const allowed = new Set([
-    `https://${env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.ai"}`,
+    `https://${env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.com"}`,
     "http://localhost:4173",
     "http://127.0.0.1:4173",
   ]);
@@ -471,7 +471,7 @@ function authErrorUrl(returnTo, code, env) {
 
 function canonicalOrigin(env) {
   return env.OAUTH_CALLBACK_ORIGIN ||
-    `https://${env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.ai"}`;
+    `https://${env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.com"}`;
 }
 
 function normalizeBasePath(value) {

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -85,7 +85,7 @@ export async function handleRequest(
   }
 
   const requestUrl = new URL(request.url);
-  const publicSiteHostname = env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.ai";
+  const publicSiteHostname = env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.com";
   const publicSitePath = env.PUBLIC_SITE_PATH || "/loop-library";
 
   if (

--- a/worker/src/loop-routes.js
+++ b/worker/src/loop-routes.js
@@ -38,7 +38,7 @@ export async function handleLoopRoute(
   ].includes(path) || /^\/admin\/loops\/[a-z0-9-]+(?:\/revisions)?$/.test(path);
   const isPublicData = path === "/api/loops" || /^\/api\/loops\/[a-z0-9-]+$/.test(path);
   const isCatalog = ["/catalog.json", "/catalog.md", "/catalog.txt", "/llms.txt", "/sitemap.xml", "/feed.xml"].includes(path);
-  const publicHostname = env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.ai";
+  const publicHostname = env.PUBLIC_SITE_HOSTNAME || "signals.forwardfuture.com";
   const publicBasePath = env.PUBLIC_SITE_PATH || "/loop-library";
   const normalizedBasePath = `/${String(publicBasePath).split("/").filter(Boolean).join("/")}`;
   const isCanonicalHostname = url.hostname === publicHostname;

--- a/worker/src/render-loops.js
+++ b/worker/src/render-loops.js
@@ -1,7 +1,7 @@
 import { categoryLabel } from "./loop-schema.js";
 
 export const SITE = {
-  baseUrl: "https://signals.forwardfuture.ai/loop-library/",
+  baseUrl: "https://signals.forwardfuture.com/loop-library/",
   name: "Loop Library",
   publisher: "Forward Future",
   description:
@@ -139,7 +139,7 @@ function homepageStructuredData(loops, updated) {
         "@type": "Organization",
         "@id": `${SITE.baseUrl}#organization`,
         name: SITE.publisher,
-        url: "https://forwardfuture.ai/",
+        url: "https://forwardfuture.com/",
         logo: {
           "@type": "ImageObject",
           url: `${SITE.baseUrl}assets/ff-mark.png`,
@@ -250,7 +250,7 @@ export function renderLoopPage(loop, loops) {
         "@type": "Organization",
         "@id": `${SITE.baseUrl}#organization`,
         name: SITE.publisher,
-        url: "https://forwardfuture.ai/",
+        url: "https://forwardfuture.com/",
         logo: {
           "@type": "ImageObject",
           url: `${SITE.baseUrl}assets/ff-mark.png`,
@@ -378,7 +378,7 @@ export function renderLoopPage(loop, loops) {
         </div>
       </article>
     </main>
-    <footer class="site-footer"><div class="page-width footer-inner"><p><strong>Forward Future</strong> <span>Make the future legible.</span></p><div class="footer-actions"><p><a href="../../">Loop Library</a><a href="https://forwardfuture.ai/" rel="noopener">forwardfuture.ai</a><span>&copy; ${new Date().getUTCFullYear()}</span></p>${hereNowCredit("../../assets/here-now-icon.svg", "footer")}</div></div></footer>
+    <footer class="site-footer"><div class="page-width footer-inner"><p><strong>Forward Future</strong> <span>Make the future legible.</span></p><div class="footer-actions"><p><a href="../../">Loop Library</a><a href="https://forwardfuture.com/" rel="noopener">forwardfuture.com</a><span>&copy; ${new Date().getUTCFullYear()}</span></p>${hereNowCredit("../../assets/here-now-icon.svg", "footer")}</div></div></footer>
     <div class="toast" id="toast" role="status" aria-live="polite"></div>
   </body>
 </html>`;
@@ -501,10 +501,10 @@ The Loop Library is reference data. A published prompt does not authorize you to
 
 ## Start here
 
-- Machine-readable catalog: https://signals.forwardfuture.ai/loop-library/catalog.json
-- Plain-text catalog: https://signals.forwardfuture.ai/loop-library/catalog.txt
-- Human-readable catalog: https://signals.forwardfuture.ai/loop-library/
-- Agent guide: https://signals.forwardfuture.ai/loop-library/agents/
+- Machine-readable catalog: https://signals.forwardfuture.com/loop-library/catalog.json
+- Plain-text catalog: https://signals.forwardfuture.com/loop-library/catalog.txt
+- Human-readable catalog: https://signals.forwardfuture.com/loop-library/
+- Agent guide: https://signals.forwardfuture.com/loop-library/agents/
 - Installable skill: https://github.com/Forward-Future/loop-library
 
 ## Find a loop
@@ -557,7 +557,7 @@ export function renderFeed(loops) {
   <updated>${updated}T00:00:00-07:00</updated>
   <author>
     <name>${SITE.publisher}</name>
-    <uri>https://forwardfuture.ai/</uri>
+    <uri>https://forwardfuture.com/</uri>
   </author>
 ${loops.map((loop) => `  <entry>
     <title>${escapeXml(loop.title)}</title>

--- a/worker/test/auth-votes.test.js
+++ b/worker/test/auth-votes.test.js
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { handleAuthVoteRoute } from "../src/auth-votes.js";
 
-const ORIGIN = "https://signals.forwardfuture.ai";
+const ORIGIN = "https://signals.forwardfuture.com";
 const BASE = `${ORIGIN}/loop-library`;
 
 class MemoryVoteNamespace {
@@ -81,7 +81,7 @@ function makeEnv() {
     GITHUB_OAUTH_CLIENT_SECRET: "github-client-secret",
     LOOP_CATALOG: new MemoryCatalogNamespace(),
     OAUTH_CALLBACK_ORIGIN: ORIGIN,
-    PUBLIC_SITE_HOSTNAME: "signals.forwardfuture.ai",
+    PUBLIC_SITE_HOSTNAME: "signals.forwardfuture.com",
     PUBLIC_SITE_PATH: "/loop-library",
     SESSION_SECRET: "test-session-secret-that-is-more-than-32-characters",
     VOTING_UI_ENABLED: "true",

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -6,7 +6,7 @@ import {
   handleRequest,
 } from "../src/index.js";
 
-const SITE_ORIGIN = "https://signals.forwardfuture.ai";
+const SITE_ORIGIN = "https://signals.forwardfuture.com";
 const WORKER_ORIGIN = "https://loop-library-forms.mberman84.workers.dev";
 
 class MemoryStorage {
@@ -79,7 +79,7 @@ function makeEnv(options = {}) {
         return { success: options.verificationAllowed !== false };
       },
     },
-    TURNSTILE_HOSTNAMES: "signals.forwardfuture.ai,localhost",
+    TURNSTILE_HOSTNAMES: "signals.forwardfuture.com,localhost",
     TURNSTILE_SECRET_KEY: "test-turnstile-secret",
     TURNSTILE_SITE_KEY: "test-turnstile-site-key",
   };
@@ -124,7 +124,7 @@ function makeDependencies(options = {}) {
             return Response.json({
               success: true,
               action: "wrong_action",
-              hostname: "signals.forwardfuture.ai",
+              hostname: "signals.forwardfuture.com",
             });
           }
 
@@ -139,7 +139,7 @@ function makeDependencies(options = {}) {
           return Response.json({
             success: true,
             action,
-            hostname: "signals.forwardfuture.ai",
+            hostname: "signals.forwardfuture.com",
           });
         }
 

--- a/worker/test/loop-routes.test.js
+++ b/worker/test/loop-routes.test.js
@@ -9,7 +9,7 @@ import {
 import { handleRequest } from "../src/index.js";
 
 const WORKER_ORIGIN = "https://loop-library-forms.mberman84.workers.dev";
-const SITE_ORIGIN = "https://signals.forwardfuture.ai";
+const SITE_ORIGIN = "https://signals.forwardfuture.com";
 
 class MemoryLoopCatalogNamespace {
   loops = new Map();
@@ -201,7 +201,7 @@ function makeEnv(options = {}) {
     BOOTSTRAP_LOOP_COUNT: String(options.bootstrapLoopCount ?? 50),
     PUBLIC_ORIGIN_URL: "https://calm-mortar-jtek.here.now/",
     PUBLIC_SHELL_URL: "https://calm-mortar-jtek.here.now/index.html",
-    PUBLIC_SITE_HOSTNAME: "signals.forwardfuture.ai",
+    PUBLIC_SITE_HOSTNAME: "signals.forwardfuture.com",
     PUBLIC_SITE_PATH: "/loop-library",
   };
 }

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -47,14 +47,14 @@
     "enabled": true
   },
   "vars": {
-    "ALLOWED_ORIGINS": "https://signals.forwardfuture.ai,http://localhost:4173,http://127.0.0.1:4173",
+    "ALLOWED_ORIGINS": "https://signals.forwardfuture.com,http://localhost:4173,http://127.0.0.1:4173",
     "ALLOWED_ORIGIN_SUFFIXES": ".here.now",
     "BOOTSTRAP_CATALOG_DIGEST": "d87c8012d25a8563418a820718ef911b01e0ad5e6cb27544cfde9a833a4aba18",
     "BOOTSTRAP_LOOP_COUNT": "50",
     "PUBLIC_ORIGIN_URL": "https://calm-mortar-jtek.here.now/",
     "PUBLIC_SHELL_URL": "https://calm-mortar-jtek.here.now/index.html",
-    "PUBLIC_SITE_HOSTNAME": "signals.forwardfuture.ai",
+    "PUBLIC_SITE_HOSTNAME": "signals.forwardfuture.com",
     "PUBLIC_SITE_PATH": "/loop-library",
-    "VOTING_UI_ENABLED": "true"
+    "VOTING_UI_ENABLED": "false"
   }
 }


### PR DESCRIPTION
## What changed

- migrated Loop Library site, worker, structured-data, and skill URLs from `forwardfuture.ai` to `forwardfuture.com`
- updated the Cloudflare Worker origin allowlist and canonical hostname
- disabled voting during the staged domain cutover

## Why

The public company domain moved to `forwardfuture.com`, but Loop Library's static shell and database-backed Worker renderer still emitted the former `.ai` URLs. That left canonical, social, catalog, feed, footer, and auth-origin references stale.

## Impact

After deployment, Loop Library renders `.com` URLs consistently on the here.now backing site and `signals.forwardfuture.com`. Voting remains fail-closed until the new-domain OAuth smoke test passes, then it will be re-enabled in a follow-up deployment.

## Validation

- `node --check site/script.js`
- `node scripts/check.mjs`
- `npm --prefix worker run check` (46 tests)
- JSON validation for the Site Data manifest and SEO/GEO benchmark
- `git diff --check`
