### PR TITLE
[codex] normalize legacy domains in catalog output

### DIFF
--- a/worker/src/loop-routes.js
+++ b/worker/src/loop-routes.js
@@ -16,6 +16,8 @@ import {
 const MAX_ADMIN_BYTES = 512 * 1024;
 const MAX_RESTORE_START_BYTES = 20 * 1024 * 1024;
 const MAX_RESTORE_CHUNK_BYTES = 4 * 1024 * 1024;
+const LEGACY_PUBLIC_DOMAIN = "forwardfuture.ai";
+const CURRENT_PUBLIC_DOMAIN = "forwardfuture.com";
 const CACHE_HEADERS = {
   // Publishing is expected to be immediately visible on every generated surface.
   // Reintroduce CDN caching only with catalog-revision cache keys or explicit purge.
@@ -70,7 +72,7 @@ export async function handleLoopRoute(
   }
 
   const catalog = await readPublishedCatalog(env);
-  const loops = catalog.loops;
+  const loops = catalog.loops.map(normalizePublishedDomain);
 
   if (!catalog.initialized) {
     // A direct canonical route can safely read the legacy origin during a
@@ -599,6 +601,21 @@ async function readPublishedCatalog(env) {
   const response = await catalogFetch(env, "/published");
   if (!response.ok) throw new Error(`Loop catalog returned ${response.status}`);
   return response.json();
+}
+
+function normalizePublishedDomain(value) {
+  if (typeof value === "string") {
+    return value.replaceAll(LEGACY_PUBLIC_DOMAIN, CURRENT_PUBLIC_DOMAIN);
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizePublishedDomain);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, normalizePublishedDomain(item)]),
+    );
+  }
+  return value;
 }
 
 function catalogFetch(env, path, init) {

--- a/worker/test/loop-routes.test.js
+++ b/worker/test/loop-routes.test.js
@@ -472,6 +472,33 @@ test("renders the mounted homepage through a here.now proxy", async () => {
   assert.match(await response.text(), /The database publishing loop/);
 });
 
+test("normalizes legacy Forward Future domains on every public catalog surface", async () => {
+  const env = makeEnv();
+  await handleRequest(
+    adminRequest(exampleLoop({
+      prompt: "Read https://signals.forwardfuture.ai/loop-library/api/loops before continuing.",
+    })),
+    env,
+  );
+  const shell = `<!doctype html><p id="results-count" aria-live="polite">Showing 0 loops</p><time datetime="2026-06-20">Updated June 20, 2026</time><tbody><!-- LOOP_DATABASE_ROWS_START --><!-- LOOP_DATABASE_ROWS_END --></tbody>`;
+  const responses = await Promise.all([
+    handleRequest(
+      new Request(`${SITE_ORIGIN}/loop-library/`),
+      env,
+      undefined,
+      { async fetch() { return new Response(shell, { headers: { "Content-Type": "text/html" } }); } },
+    ),
+    handleRequest(new Request(`${SITE_ORIGIN}/loop-library/catalog.json`), env),
+    handleRequest(new Request(`${SITE_ORIGIN}/loop-library/api/loops`), env),
+  ]);
+
+  for (const response of responses) {
+    const body = await response.text();
+    assert.doesNotMatch(body, /forwardfuture\.ai/);
+    assert.match(body, /signals\.forwardfuture\.com\/loop-library\/api\/loops/);
+  }
+});
+
 test("does not recurse through the here.now proxy before activation", async () => {
   const env = makeEnv({ active: false });
   let originFetches = 0;


### PR DESCRIPTION
## What changed

- normalizes the former `forwardfuture.ai` domain to `forwardfuture.com` when production catalog records are exposed through public surfaces
- covers the homepage, catalog JSON, and public API with a regression test

## Why

One production catalog prompt predates the domain migration. The Worker correctly migrated all generated URLs, but that stored prompt still surfaced the former host in the homepage and machine-readable catalog.

## Impact

All public Loop Library representations now use the current domain without mutating or rewriting the production catalog database or its revision history.

## Validation

- `node --check site/script.js`
- `node scripts/check.mjs`
- `npm --prefix worker run check` (47 tests)
- JSON validation for the Site Data manifest and SEO/GEO benchmark
- `git diff --check`
