### PR TITLE
[codex] re-enable Loop Library voting

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -248,7 +248,7 @@ assert.equal(wrangler.vars.PUBLIC_ORIGIN_URL, "https://calm-mortar-jtek.here.now
 assert.equal(wrangler.vars.PUBLIC_SHELL_URL, "https://calm-mortar-jtek.here.now/index.html");
 assert.equal(wrangler.vars.PUBLIC_SITE_HOSTNAME, "signals.forwardfuture.com");
 assert.equal(wrangler.vars.PUBLIC_SITE_PATH, "/loop-library");
-assert.equal(wrangler.vars.VOTING_UI_ENABLED, "false");
+assert.equal(wrangler.vars.VOTING_UI_ENABLED, "true");
 assert.deepEqual(Object.keys(proxyManifest.proxies).sort(), [
   "/",
   "/api/loops",

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -55,6 +55,6 @@
     "PUBLIC_SHELL_URL": "https://calm-mortar-jtek.here.now/index.html",
     "PUBLIC_SITE_HOSTNAME": "signals.forwardfuture.com",
     "PUBLIC_SITE_PATH": "/loop-library",
-    "VOTING_UI_ENABLED": "false"
+    "VOTING_UI_ENABLED": "true"
   }
 }


### PR DESCRIPTION
## What changed

- re-enables Loop Library community voting after the domain-migration safety gate
- updates the repository invariant to require voting to remain enabled

## Why

Voting was intentionally disabled while the GitHub OAuth application homepage and callback moved from `forwardfuture.ai` to `forwardfuture.com`. The OAuth settings are updated and the canonical nonce-bound GitHub redirect now returns cleanly to the `.com` Loop Library without an auth error.

## Impact

Visitors can sign in with GitHub and vote on published loops again using the current canonical domain.

## Validation

- canonical `.com` GitHub OAuth redirect smoke test
- `node --check site/script.js`
- `node scripts/check.mjs`
- `npm --prefix worker run check` (47 tests)
- JSON validation for the Site Data manifest and SEO/GEO benchmark
- `git diff --check`
