### PR TITLE
Serve a branded homepage fallback when the here.now shell is unavailable

### DIFF
--- a/loop-library/worker/src/loop-routes.js
+++ b/loop-library/worker/src/loop-routes.js
@@ -9,6 +9,7 @@ import {
   renderAgentInstructions,
   renderCatalogMarkdown,
   renderFeed,
+  renderHomepageFallback,
   renderLoopPage,
   renderSitemap,
 } from "./render-loops.js";
@@ -159,7 +160,33 @@ export async function handleLoopRoute(
           conditional: false,
           range: false,
         });
-    const originResponse = await dependencies.fetch(originRequest);
+    let originResponse;
+    try {
+      originResponse = await dependencies.fetch(originRequest);
+    } catch {
+      // The here.now shell is unreachable. Serve a branded fallback built from
+      // the catalog the Worker already holds so every loop stays reachable,
+      // rather than leaking the upstream failure. Report it honestly as 502.
+      return textResponse(
+        renderHomepageFallback(loops),
+        "text/html; charset=utf-8",
+        502,
+        CACHE_HEADERS,
+        request.method,
+      );
+    }
+
+    if (originResponse.status >= 500) {
+      // Upstream shell error: serve the same fallback and preserve the real
+      // failure status instead of passing through the upstream error page.
+      return textResponse(
+        renderHomepageFallback(loops),
+        "text/html; charset=utf-8",
+        originResponse.status,
+        CACHE_HEADERS,
+        request.method,
+      );
+    }
 
     if (!originResponse.ok) {
       return originResponse;

--- a/loop-library/worker/src/render-loops.js
+++ b/loop-library/worker/src/render-loops.js
@@ -384,6 +384,69 @@ export function renderLoopPage(loop, loops) {
 </html>`;
 }
 
+export function renderHomepageFallback(loops) {
+  const items = loops
+    .map(
+      (loop) =>
+        `        <li class="fallback-loop"><a href="${SITE.baseUrl}loops/${escapeHtml(loop.slug)}/">${escapeHtml(loop.title)}</a><p>${escapeHtml(loop.summary)}</p></li>`,
+    )
+    .join("\n");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="${escapeHtml(SITE.description)}" />
+    <meta name="robots" content="noindex" />
+    <meta name="theme-color" content="#faf8f7" />
+    <meta name="color-scheme" content="light dark" />
+    <script>
+      (() => {
+        const storageKey = "loop-library-theme";
+        let storedTheme;
+        try { storedTheme = window.localStorage.getItem(storageKey); } catch { storedTheme = null; }
+        const theme = storedTheme === "light" || storedTheme === "dark"
+          ? storedTheme
+          : window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        document.documentElement.dataset.theme = theme;
+        document.querySelector('meta[name="theme-color"]')
+          .setAttribute("content", theme === "dark" ? "#101010" : "#faf8f7");
+      })();
+    </script>
+    <link rel="canonical" href="${SITE.baseUrl}" />
+    <link rel="alternate" type="application/json" title="Loop Library catalog" href="${SITE.baseUrl}catalog.json" />
+    <link rel="alternate" type="text/plain" title="${SITE.name} agent instructions" href="${SITE.baseUrl}llms.txt" />
+    <link rel="icon" type="image/png" href="${SITE.baseUrl}assets/favicon.png" />
+    <link rel="stylesheet" href="${SITE.baseUrl}styles.css" />
+    <title>${escapeHtml(SITE.name)} — temporarily unavailable</title>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
+      <a class="brand-lockup" href="${SITE.baseUrl}" aria-label="Forward Future Loop Library home">
+        <img class="brand-mark" src="${SITE.baseUrl}assets/favicon.png" width="32" height="32" alt="" />
+        <span class="brand-name">Forward Future</span>
+        <span class="brand-product">Loop Library</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary navigation">
+        <a href="${SITE.baseUrl}learn/">Learn</a>
+        <a href="${SITE.baseUrl}agents/">For agents</a>
+      </nav>
+    </header>
+    <main class="detail-main page-width" id="main">
+      <h1>The Loop Library is briefly unavailable</h1>
+      <p>The full homepage could not be loaded right now. Every published loop is still listed below, and the machine-readable <a href="${SITE.baseUrl}catalog.json">catalog.json</a> and <a href="${SITE.baseUrl}llms.txt">agent instructions</a> remain available.</p>
+      <p>Showing ${loops.length} loops.</p>
+      <ul class="fallback-loop-list">
+${items}
+      </ul>
+    </main>
+    <footer class="site-footer"><div class="page-width footer-inner"><p><strong>Forward Future</strong> <span>Make the future legible.</span></p><p><a href="${SITE.baseUrl}">Loop Library</a> <a href="https://forwardfuture.com/" rel="noopener">forwardfuture.com</a></p></div></footer>
+  </body>
+</html>`;
+}
+
 function shareActions(loop, url) {
   const text = `Try "${loop.title}" from the Loop Library: ${loop.summary}`;
   return `<div class="share-actions" aria-label="Share this loop"><button class="share-action share-action-primary" type="button" data-copy-social-post data-post-text="${escapeHtml(text)}" data-post-url="${escapeHtml(url)}" aria-label="Copy a social post about ${escapeHtml(loop.title)}"><svg class="share-copy-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="8" width="11" height="11"></rect><path d="M16 8V5a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h3"></path></svg><span>Share on social</span></button></div>`;

--- a/loop-library/worker/test/loop-routes.test.js
+++ b/loop-library/worker/test/loop-routes.test.js
@@ -472,6 +472,53 @@ test("renders the mounted homepage through a here.now proxy", async () => {
   assert.match(await response.text(), /The database publishing loop/);
 });
 
+test("serves a branded fallback homepage when the here.now shell errors", async () => {
+  const env = makeEnv();
+  await handleRequest(adminRequest(exampleLoop()), env);
+  const response = await handleRequest(
+    new Request(`${SITE_ORIGIN}/loop-library/`),
+    env,
+    undefined,
+    {
+      async fetch() {
+        return new Response("upstream is down", { status: 503 });
+      },
+    },
+  );
+  const html = await response.text();
+
+  // Preserves the real failure status instead of masking it as 200.
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
+  // Branded fallback that still lists every loop, not the upstream error body.
+  assert.doesNotMatch(html, /upstream is down/);
+  assert.match(html, /briefly unavailable/);
+  assert.match(html, /The database publishing loop/);
+  assert.match(html, /loops\/database-publishing-loop\//);
+  assert.match(html, /catalog\.json/);
+  assert.match(html, /<meta name="robots" content="noindex"/);
+});
+
+test("serves the fallback homepage when the here.now shell is unreachable", async () => {
+  const env = makeEnv();
+  await handleRequest(adminRequest(exampleLoop()), env);
+  const response = await handleRequest(
+    new Request(`${SITE_ORIGIN}/loop-library/`),
+    env,
+    undefined,
+    {
+      async fetch() {
+        throw new Error("connection refused");
+      },
+    },
+  );
+  const html = await response.text();
+
+  assert.equal(response.status, 502);
+  assert.match(html, /briefly unavailable/);
+  assert.match(html, /The database publishing loop/);
+});
+
 test("normalizes legacy Forward Future domains on every public catalog surface", async () => {
   const env = makeEnv();
   await handleRequest(


### PR DESCRIPTION
## Summary

The homepage is served by fetching the here.now shell, injecting the catalog, and returning it (`loop-routes.js`). When that origin fetch **throws** or the shell returns a **5xx**, the Worker passed the upstream failure straight through:

```js
const originResponse = await dependencies.fetch(originRequest);
if (!originResponse.ok) return originResponse;
```

So during a shell/here.now hiccup, visitors hit an unbranded, catalog-less dead end — even though the Worker already holds **every loop record in its own database** and renders detail pages from it.

## Change

When the shell is unavailable on the homepage, render a **minimal branded fallback** from the catalog the Worker already has, instead of leaking the upstream error:

- Keeps the site chrome (header/nav/footer) and theme.
- Lists **every published loop with working links**, so nothing becomes unreachable during an outage.
- Points agents at `catalog.json` and `llms.txt` (still live).
- **Preserves the real failure status** — the upstream 5xx, or `502` when the shell is unreachable — so the outage stays honest, and marks the page `noindex` so the degraded view isn't indexed.

Behavior is unchanged on the happy path and for non-5xx responses (4xx still passes through as before). Detail pages already render from the DB, so they're unaffected.

## Files
- `worker/src/render-loops.js` — new `renderHomepageFallback(loops)`.
- `worker/src/loop-routes.js` — serve it on a thrown fetch (502) or upstream 5xx (status preserved).
- `worker/test/loop-routes.test.js` — two tests (5xx → branded 503 fallback, not the upstream body; unreachable → 502).

## Verification
- `npm --prefix loop-library/worker run check` → 49/49 pass.
- `node loop-library/scripts/check.mjs` → "Loop Library database-only checks passed."
- `git diff --check` → clean.

Happy to adjust or close if you'd rather the homepage stay strictly shell-driven on failure — this is meant as a resilience nicety, leaning on the fact that the Worker is now the source of truth for loops.
