### PR TITLE
Add dedicated "Most popular" sort to the loop library

### DIFF
--- a/loop-library/scripts/check.mjs
+++ b/loop-library/scripts/check.mjs
@@ -184,6 +184,8 @@ assert(browserScript.includes('params.set("sort", activeSort)'));
 assert(browserScript.includes("function comparePopular"));
 assert(browserScript.includes("Number(b.dataset.upvotes || 0)"));
 assert(html.includes('<option value="featured">Featured, then popular</option>'));
+assert(html.includes('<option value="popular">Most popular</option>'));
+assert(browserScript.includes('activeSort === "popular"'));
 assert(browserScript.includes("library-pagination"));
 assert(!browserScript.includes("innerHTML"));
 

--- a/loop-library/scripts/check.mjs
+++ b/loop-library/scripts/check.mjs
@@ -143,7 +143,7 @@ assert(html.includes("Search the library"));
 assert(html.includes("Search by title, task, or contributor"));
 assert(html.includes('class="search-field"'));
 assert(html.includes("styles.css?v=20260623-row-background-v2"));
-assert(html.includes("script.js?v=20260625-form-protection"));
+assert(html.includes("script.js?v=20260702-popular-sort"));
 assert(css.includes(".search-control-label"));
 assert(css.includes(".search-control:hover .search-field"));
 assert(css.includes(".search-control:focus-within .search-field"));
@@ -152,7 +152,7 @@ assert.match(css, /\.loop-table td\s*\{[^}]*background:\s*transparent;[^}]*\}/);
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
 for (const page of [learnHtml, agentHtml]) {
   assert(page.includes("styles.css?v=20260623-row-background-v2"));
-  assert(page.includes("script.js?v=20260625-form-protection"));
+  assert(page.includes("script.js?v=20260702-popular-sort"));
 }
 for (const page of [html, learnHtml, agentHtml]) {
   const brandPosition = page.indexOf('class="brand-lockup"');

--- a/loop-library/site/agents/index.html
+++ b/loop-library/site/agents/index.html
@@ -77,7 +77,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260623-row-background-v2" />
-    <script src="../script.js?v=20260625-form-protection" defer></script>
+    <script src="../script.js?v=20260702-popular-sort" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/loop-library/site/index.html
+++ b/loop-library/site/index.html
@@ -430,6 +430,7 @@
               <span>Sort</span>
               <select id="loop-sort">
                 <option value="featured">Featured, then popular</option>
+                <option value="popular">Most popular</option>
                 <option value="newest">Newest → oldest</option>
                 <option value="oldest">Oldest → newest</option>
                 <option value="alphabetical">A–Z</option>

--- a/loop-library/site/index.html
+++ b/loop-library/site/index.html
@@ -198,7 +198,7 @@
   ]
 }
     </script>
-    <script src="./script.js?v=20260625-form-protection" defer></script>
+    <script src="./script.js?v=20260702-popular-sort" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>

--- a/loop-library/site/learn/index.html
+++ b/loop-library/site/learn/index.html
@@ -75,7 +75,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260623-row-background-v2" />
-    <script src="../script.js?v=20260625-form-protection" defer></script>
+    <script src="../script.js?v=20260702-popular-sort" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/loop-library/site/script.js
+++ b/loop-library/site/script.js
@@ -75,6 +75,7 @@ const loopRowPositions = new Map(
 );
 const SORT_OPTIONS = new Set([
   "featured",
+  "popular",
   "newest",
   "oldest",
   "alphabetical",
@@ -153,6 +154,10 @@ function applySort(sort) {
       return rowTitle(a).localeCompare(rowTitle(b), undefined, {
         sensitivity: "base",
       });
+    }
+
+    if (activeSort === "popular") {
+      return comparePopular(a, b);
     }
 
     if (activeSort === "newest") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a standalone **Most popular** option to the homepage sort control. Votes previously only influenced ordering as a tiebreaker inside "Featured, then popular"; this makes community votes directly browsable.

- New `Most popular` option in the sort select, ordering rows by upvotes (ties fall back to newest)
- Reuses the existing `comparePopular` comparator and live vote totals from `/api/votes`, so rows re-rank when votes load or change
- Deep links via `?sort=popular` work through the existing URL state handling
- Script cache tag bumped to `20260702-popular-sort` on all three shell pages so browsers fetch the updated script after the next publish
- Repository checks extended to guard the new option and cache tag

## Verification

- `node --check loop-library/site/script.js`
- `node loop-library/scripts/check.mjs`
- `npm --prefix loop-library/worker run check` (47/47 tests pass)
- JSON manifests validated, `git diff --check` clean

No Worker or schema changes; this is shell-only and takes effect with the next site publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f209c-11bf-75bd-886b-31438c09c5db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f209c-11bf-75bd-886b-31438c09c5db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

