### PR TITLE
Integrate PRs #85, #89, and #90

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,13 +53,14 @@ this repository layout.
   node loop-library/scripts/check.mjs
   npm --prefix loop-library/worker run check
   python3 -m json.tool loop-library/site/.herenow/data.json >/dev/null
+  python3 -m json.tool loop-library/site/.herenow/proxy.json >/dev/null
   python3 -m json.tool loop-library/scripts/seo-geo-query-benchmark.json >/dev/null
   git diff --check
   ```
 
 - Do not publish a loop unless its public homepage row, detail page,
-  `catalog.json`, `catalog.md`, sitemap, and feed all read back from production
-  with the expected slug and modified date.
+  `catalog.json`, `catalog.md`, `catalog.txt`, `llms.txt`, sitemap, and feed
+  all read back from production with the expected slug and modified date.
 
 ## Protected forms
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ node --check loop-library/site/script.js
 node loop-library/scripts/check.mjs
 npm --prefix loop-library/worker run check
 python3 -m json.tool loop-library/site/.herenow/data.json >/dev/null
+python3 -m json.tool loop-library/site/.herenow/proxy.json >/dev/null
 python3 -m json.tool loop-library/scripts/seo-geo-query-benchmark.json >/dev/null
 git diff --check
 ```

--- a/loop-library/scripts/check.mjs
+++ b/loop-library/scripts/check.mjs
@@ -40,6 +40,7 @@ const [
   legacySkillPublish,
   readme,
   agents,
+  ciWorkflow,
 ] = await Promise.all([
   readFile(path.join(siteRoot, "index.html"), "utf8"),
   readFile(path.join(siteRoot, "learn", "index.html"), "utf8"),
@@ -69,6 +70,7 @@ const [
   readFile(path.join(legacySkillRoot, "references", "publish.md"), "utf8"),
   readFile(path.join(repoRoot, "README.md"), "utf8"),
   readFile(path.join(repoRoot, "AGENTS.md"), "utf8"),
+  readFile(path.join(repoRoot, ".github", "workflows", "ci.yml"), "utf8"),
 ]);
 
 const workerPackage = JSON.parse(workerPackageSource);
@@ -371,5 +373,21 @@ assert(readme.includes("loops:export"));
 assert(readme.includes("loops:restore"));
 assert(agents.includes("Do not commit"));
 assert(agents.includes("Never publish the empty shell"));
+assert(
+  agents.includes("`catalog.json`, `catalog.md`, `catalog.txt`, `llms.txt`, sitemap, and feed"),
+);
+for (const command of [
+  "node --check loop-library/site/script.js",
+  "node loop-library/scripts/check.mjs",
+  "npm --prefix loop-library/worker run check",
+  "python3 -m json.tool loop-library/site/.herenow/data.json >/dev/null",
+  "python3 -m json.tool loop-library/site/.herenow/proxy.json >/dev/null",
+  "python3 -m json.tool loop-library/scripts/seo-geo-query-benchmark.json >/dev/null",
+  "git diff --check",
+]) {
+  assert(readme.includes(command), `README.md missing validation command: ${command}`);
+  assert(agents.includes(command), `AGENTS.md missing validation command: ${command}`);
+  assert(ciWorkflow.includes(command), `.github/workflows/ci.yml missing validation command: ${command}`);
+}
 
 console.log("Loop Library database-only checks passed.");

--- a/loop-library/scripts/check.mjs
+++ b/loop-library/scripts/check.mjs
@@ -184,6 +184,8 @@ assert(browserScript.includes('params.set("sort", activeSort)'));
 assert(browserScript.includes("function comparePopular"));
 assert(browserScript.includes("Number(b.dataset.upvotes || 0)"));
 assert(html.includes('<option value="featured">Featured, then popular</option>'));
+assert(html.includes('<option value="popular">Most popular</option>'));
+assert(browserScript.includes('activeSort === "popular"'));
 assert(browserScript.includes("library-pagination"));
 assert(!browserScript.includes("innerHTML"));
 

--- a/loop-library/scripts/check.mjs
+++ b/loop-library/scripts/check.mjs
@@ -143,7 +143,7 @@ assert(html.includes("Search the library"));
 assert(html.includes("Search by title, task, or contributor"));
 assert(html.includes('class="search-field"'));
 assert(html.includes("styles.css?v=20260623-row-background-v2"));
-assert(html.includes("script.js?v=20260625-form-protection"));
+assert(html.includes("script.js?v=20260702-popular-sort"));
 assert(css.includes(".search-control-label"));
 assert(css.includes(".search-control:hover .search-field"));
 assert(css.includes(".search-control:focus-within .search-field"));
@@ -152,7 +152,7 @@ assert.match(css, /\.loop-table td\s*\{[^}]*background:\s*transparent;[^}]*\}/);
 assert.equal((html.match(/data-here-now-credit/g) || []).length, 2);
 for (const page of [learnHtml, agentHtml]) {
   assert(page.includes("styles.css?v=20260623-row-background-v2"));
-  assert(page.includes("script.js?v=20260625-form-protection"));
+  assert(page.includes("script.js?v=20260702-popular-sort"));
 }
 for (const page of [html, learnHtml, agentHtml]) {
   const brandPosition = page.indexOf('class="brand-lockup"');

--- a/loop-library/site/agents/index.html
+++ b/loop-library/site/agents/index.html
@@ -77,7 +77,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260623-row-background-v2" />
-    <script src="../script.js?v=20260625-form-protection" defer></script>
+    <script src="../script.js?v=20260702-popular-sort" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/loop-library/site/index.html
+++ b/loop-library/site/index.html
@@ -430,6 +430,7 @@
               <span>Sort</span>
               <select id="loop-sort">
                 <option value="featured">Featured, then popular</option>
+                <option value="popular">Most popular</option>
                 <option value="newest">Newest → oldest</option>
                 <option value="oldest">Oldest → newest</option>
                 <option value="alphabetical">A–Z</option>

--- a/loop-library/site/index.html
+++ b/loop-library/site/index.html
@@ -198,7 +198,7 @@
   ]
 }
     </script>
-    <script src="./script.js?v=20260625-form-protection" defer></script>
+    <script src="./script.js?v=20260702-popular-sort" defer></script>
     <title>Loop Library: Repeatable AI Agent Workflows | Forward Future</title>
   </head>
   <body>

--- a/loop-library/site/learn/index.html
+++ b/loop-library/site/learn/index.html
@@ -75,7 +75,7 @@
     />
     <link rel="icon" type="image/png" href="../assets/favicon.png" />
     <link rel="stylesheet" href="../styles.css?v=20260623-row-background-v2" />
-    <script src="../script.js?v=20260625-form-protection" defer></script>
+    <script src="../script.js?v=20260702-popular-sort" defer></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/loop-library/site/script.js
+++ b/loop-library/site/script.js
@@ -75,6 +75,7 @@ const loopRowPositions = new Map(
 );
 const SORT_OPTIONS = new Set([
   "featured",
+  "popular",
   "newest",
   "oldest",
   "alphabetical",
@@ -153,6 +154,10 @@ function applySort(sort) {
       return rowTitle(a).localeCompare(rowTitle(b), undefined, {
         sensitivity: "base",
       });
+    }
+
+    if (activeSort === "popular") {
+      return comparePopular(a, b);
     }
 
     if (activeSort === "newest") {

--- a/loop-library/worker/src/auth-votes.js
+++ b/loop-library/worker/src/auth-votes.js
@@ -42,6 +42,7 @@ export async function handleAuthVoteRoute(
     if (body instanceof Response) return body;
     const viewer = await readSession(body.sessionToken, env);
     if (!viewer) return jsonResponse({ viewer: null, viewerVotes: {} });
+    if (!env.VOTE_STORE) return unavailable("Voting is not configured.");
     const response = await voteStoreFetch(
       env,
       `/votes?voter=${encodeURIComponent(viewer.sub)}`,

--- a/loop-library/worker/src/loop-routes.js
+++ b/loop-library/worker/src/loop-routes.js
@@ -9,6 +9,7 @@ import {
   renderAgentInstructions,
   renderCatalogMarkdown,
   renderFeed,
+  renderHomepageFallback,
   renderLoopPage,
   renderSitemap,
 } from "./render-loops.js";
@@ -159,7 +160,33 @@ export async function handleLoopRoute(
           conditional: false,
           range: false,
         });
-    const originResponse = await dependencies.fetch(originRequest);
+    let originResponse;
+    try {
+      originResponse = await dependencies.fetch(originRequest);
+    } catch {
+      // The here.now shell is unreachable. Serve a branded fallback built from
+      // the catalog the Worker already holds so every loop stays reachable,
+      // rather than leaking the upstream failure. Report it honestly as 502.
+      return textResponse(
+        renderHomepageFallback(loops),
+        "text/html; charset=utf-8",
+        502,
+        CACHE_HEADERS,
+        request.method,
+      );
+    }
+
+    if (originResponse.status >= 500) {
+      // Upstream shell error: serve the same fallback and preserve the real
+      // failure status instead of passing through the upstream error page.
+      return textResponse(
+        renderHomepageFallback(loops),
+        "text/html; charset=utf-8",
+        originResponse.status,
+        CACHE_HEADERS,
+        request.method,
+      );
+    }
 
     if (!originResponse.ok) {
       return originResponse;

--- a/loop-library/worker/src/render-loops.js
+++ b/loop-library/worker/src/render-loops.js
@@ -384,6 +384,69 @@ export function renderLoopPage(loop, loops) {
 </html>`;
 }
 
+export function renderHomepageFallback(loops) {
+  const items = loops
+    .map(
+      (loop) =>
+        `        <li class="fallback-loop"><a href="${SITE.baseUrl}loops/${escapeHtml(loop.slug)}/">${escapeHtml(loop.title)}</a><p>${escapeHtml(loop.summary)}</p></li>`,
+    )
+    .join("\n");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="${escapeHtml(SITE.description)}" />
+    <meta name="robots" content="noindex" />
+    <meta name="theme-color" content="#faf8f7" />
+    <meta name="color-scheme" content="light dark" />
+    <script>
+      (() => {
+        const storageKey = "loop-library-theme";
+        let storedTheme;
+        try { storedTheme = window.localStorage.getItem(storageKey); } catch { storedTheme = null; }
+        const theme = storedTheme === "light" || storedTheme === "dark"
+          ? storedTheme
+          : window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        document.documentElement.dataset.theme = theme;
+        document.querySelector('meta[name="theme-color"]')
+          .setAttribute("content", theme === "dark" ? "#101010" : "#faf8f7");
+      })();
+    </script>
+    <link rel="canonical" href="${SITE.baseUrl}" />
+    <link rel="alternate" type="application/json" title="Loop Library catalog" href="${SITE.baseUrl}catalog.json" />
+    <link rel="alternate" type="text/plain" title="${SITE.name} agent instructions" href="${SITE.baseUrl}llms.txt" />
+    <link rel="icon" type="image/png" href="${SITE.baseUrl}assets/favicon.png" />
+    <link rel="stylesheet" href="${SITE.baseUrl}styles.css" />
+    <title>${escapeHtml(SITE.name)} — temporarily unavailable</title>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
+      <a class="brand-lockup" href="${SITE.baseUrl}" aria-label="Forward Future Loop Library home">
+        <img class="brand-mark" src="${SITE.baseUrl}assets/favicon.png" width="32" height="32" alt="" />
+        <span class="brand-name">Forward Future</span>
+        <span class="brand-product">Loop Library</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary navigation">
+        <a href="${SITE.baseUrl}learn/">Learn</a>
+        <a href="${SITE.baseUrl}agents/">For agents</a>
+      </nav>
+    </header>
+    <main class="detail-main page-width" id="main">
+      <h1>The Loop Library is briefly unavailable</h1>
+      <p>The full homepage could not be loaded right now. Every published loop is still listed below, and the machine-readable <a href="${SITE.baseUrl}catalog.json">catalog.json</a> and <a href="${SITE.baseUrl}llms.txt">agent instructions</a> remain available.</p>
+      <p>Showing ${loops.length} loops.</p>
+      <ul class="fallback-loop-list">
+${items}
+      </ul>
+    </main>
+    <footer class="site-footer"><div class="page-width footer-inner"><p><strong>Forward Future</strong> <span>Make the future legible.</span></p><p><a href="${SITE.baseUrl}">Loop Library</a> <a href="https://forwardfuture.com/" rel="noopener">forwardfuture.com</a></p></div></footer>
+  </body>
+</html>`;
+}
+
 function shareActions(loop, url) {
   const text = `Try "${loop.title}" from the Loop Library: ${loop.summary}`;
   return `<div class="share-actions" aria-label="Share this loop"><button class="share-action share-action-primary" type="button" data-copy-social-post data-post-text="${escapeHtml(text)}" data-post-url="${escapeHtml(url)}" aria-label="Copy a social post about ${escapeHtml(loop.title)}"><svg class="share-copy-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="8" width="11" height="11"></rect><path d="M16 8V5a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h3"></path></svg><span>Share on social</span></button></div>`;

--- a/loop-library/worker/test/auth-votes.test.js
+++ b/loop-library/worker/test/auth-votes.test.js
@@ -219,6 +219,24 @@ test("voting UI is fail-closed unless the launch flag is exactly true", async ()
   assert.equal((await enabled.json()).uiEnabled, true);
 });
 
+test("session lookup fails closed when vote storage is unavailable", async () => {
+  const env = makeEnv();
+  const sessionToken = await githubSession(env);
+  delete env.VOTE_STORE;
+
+  const session = await handleAuthVoteRoute(
+    new Request(`${BASE}/auth/session`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionToken }),
+    }),
+    env,
+  );
+
+  assert.equal(session.status, 503);
+  assert.equal((await session.json()).code, "not_configured");
+});
+
 test("vote writes reject anonymous, cross-site, malformed, and unpublished requests", async () => {
   const env = makeEnv();
   const anonymous = await handleAuthVoteRoute(

--- a/loop-library/worker/test/loop-routes.test.js
+++ b/loop-library/worker/test/loop-routes.test.js
@@ -16,8 +16,13 @@ class MemoryLoopCatalogNamespace {
   revisions = new Map();
   restore = null;
 
-  constructor(active = true) {
+  constructor(active = true, options = {}) {
     this.active = active;
+    this.validateWrites = options.validateWrites === true;
+
+    for (const loop of options.seedLoops || []) {
+      this.loops.set(loop.slug, { ...loop });
+    }
   }
 
   idFromName(name) {
@@ -39,6 +44,10 @@ class MemoryLoopCatalogNamespace {
               { status: 409 },
             );
           }
+          const catalogError = this.catalogIntegrityError([
+            { loop: body.loop, status: body.status },
+          ]);
+          if (catalogError) return catalogError;
           this.loops.set(body.loop.slug, { ...body.loop, status: body.status });
           const revisions = this.revisions.get(body.loop.slug) || [];
           revisions.unshift({
@@ -76,6 +85,10 @@ class MemoryLoopCatalogNamespace {
 
         if (init.method === "POST" && url.pathname === "/import") {
           const body = JSON.parse(init.body);
+          const catalogError = this.catalogIntegrityError(
+            body.loops.map((loop) => ({ loop, status: body.status })),
+          );
+          if (catalogError) return catalogError;
           for (const loop of body.loops) this.loops.set(loop.slug, { ...loop, status: body.status });
           if (body.activate) this.active = true;
           return Response.json({ imported: body.loops.length });
@@ -191,11 +204,31 @@ class MemoryLoopCatalogNamespace {
       },
     };
   }
+
+  catalogIntegrityError(changes) {
+    if (!this.validateWrites) return null;
+
+    try {
+      assertCatalogIntegrity([...this.loops.values()], changes);
+      return null;
+    } catch (error) {
+      return Response.json(
+        {
+          error: error instanceof Error ? error.message : "Invalid catalog graph",
+          code: "invalid_catalog_graph",
+        },
+        { status: 409 },
+      );
+    }
+  }
 }
 
 function makeEnv(options = {}) {
   return {
-    LOOP_CATALOG: new MemoryLoopCatalogNamespace(options.active ?? true),
+    LOOP_CATALOG: new MemoryLoopCatalogNamespace(options.active ?? true, {
+      validateWrites: options.validateCatalog === true,
+      seedLoops: options.seedLoops,
+    }),
     LOOP_PUBLISH_TOKEN: "test-publish-token",
     BOOTSTRAP_CATALOG_DIGEST: options.bootstrapDigest || "test-bootstrap-digest",
     BOOTSTRAP_LOOP_COUNT: String(options.bootstrapLoopCount ?? 50),
@@ -235,6 +268,63 @@ function exampleLoop(overrides = {}) {
     related: ["overnight-docs-sweep"],
     ...overrides,
   };
+}
+
+function overnightDocsLoop(overrides = {}) {
+  return exampleLoop({
+    number: "900",
+    slug: "overnight-docs-sweep",
+    title: "The overnight docs sweep",
+    summary: "Keeps documentation refreshed during a bounded maintenance pass.",
+    seoTitle: "Overnight Docs Sweep | Loop Library",
+    description: "A loop for refreshing docs with a concrete overnight check.",
+    prompt: "Review stale docs, update the highest-value page, verify links, and stop.",
+    verifyTitle: "Docs pass the configured link and freshness checks.",
+    verifyDetail: "Run the documentation checks and inspect the changed page.",
+    useWhen: "Use this when documentation has drifted after product or code changes.",
+    steps: [
+      "Find the stale documentation surface.",
+      "Make one focused update.",
+      "Run the documentation verification checks.",
+    ],
+    why: "Small bounded updates keep docs useful without broad rewrites.",
+    note: "Stop when the check passes or when ownership is unclear.",
+    keywords: ["documentation", "maintenance", "freshness"],
+    related: ["catalog-support-loop"],
+    ...overrides,
+  });
+}
+
+function catalogSupportLoop(overrides = {}) {
+  return exampleLoop({
+    number: "901",
+    slug: "catalog-support-loop",
+    title: "The catalog support loop",
+    summary: "Provides a stable fixture for catalog graph validation.",
+    seoTitle: "Catalog Support Loop | Loop Library",
+    description: "A support loop used to validate related-loop relationships.",
+    prompt: "Check the catalog graph, confirm related links resolve, and stop.",
+    verifyTitle: "Every related loop slug resolves.",
+    verifyDetail: "Read the generated catalog and verify each related link.",
+    useWhen: "Use this when validating catalog graph behavior.",
+    steps: [
+      "Load the catalog records.",
+      "Trace each related-loop slug.",
+      "Report any missing or unpublished relationship.",
+    ],
+    why: "Graph validation prevents public pages from hiding broken relationships.",
+    note: "Keep the fixture plain so tests can assert the target loop explicitly.",
+    keywords: ["catalog graph", "related loops", "validation"],
+    related: ["overnight-docs-sweep"],
+    ...overrides,
+  });
+}
+
+function publishedSupportLoops() {
+  return [
+    { ...overnightDocsLoop(), status: "published" },
+    { ...catalogSupportLoop(), status: "published" },
+  ];
 }
 
 function adminRequest(loop, options = {}) {
@@ -284,6 +374,60 @@ test("rejects unauthorized and invalid publishing requests", async () => {
   );
   assert.equal(invalid.status, 400);
   assert.equal((await invalid.json()).code, "invalid_loop");
+});
+
+test("publishing routes reject invalid catalog graphs through the catalog store", async () => {
+  const missingRelated = makeEnv({ validateCatalog: true });
+  const missingRelatedResponse = await handleRequest(
+    adminRequest(exampleLoop({ related: ["missing-loop"] })),
+    missingRelated,
+  );
+  assert.equal(missingRelatedResponse.status, 409);
+  assert.match(
+    (await missingRelatedResponse.json()).error,
+    /references unavailable related loop missing-loop/,
+  );
+
+  const invalidImport = makeEnv({ validateCatalog: true });
+  const importResponse = await handleRequest(
+    new Request(`${WORKER_ORIGIN}/admin/loops/import`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-publish-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        loops: [exampleLoop({ related: ["missing-loop"] })],
+        status: "published",
+      }),
+    }),
+    invalidImport,
+  );
+  assert.equal(importResponse.status, 409);
+  assert.equal((await importResponse.json()).code, "invalid_catalog_graph");
+
+  const duplicateMetadata = makeEnv({
+    validateCatalog: true,
+    seedLoops: [
+      ...publishedSupportLoops(),
+      { ...exampleLoop({ related: ["overnight-docs-sweep"] }), status: "published" },
+    ],
+  });
+  const duplicateResponse = await handleRequest(
+    adminRequest(
+      exampleLoop({
+        number: "052",
+        slug: "duplicate-title-loop",
+        related: ["overnight-docs-sweep"],
+      }),
+    ),
+    duplicateMetadata,
+  );
+  assert.equal(duplicateResponse.status, 409);
+  assert.match(
+    (await duplicateResponse.json()).error,
+    /duplicate-title-loop.title duplicates database-publishing-loop.title/,
+  );
 });
 
 test("rejects a stale publisher instead of overwriting a newer revision", async () => {
@@ -410,6 +554,31 @@ test("renders database content into the canonical homepage and detail page", asy
     assert.match(detailHtml, new RegExp(`property="${property}"`));
   }
   assert.match(detailHtml, /name="twitter:image:alt"/);
+});
+
+test("renders related links from a catalog graph validated by the store", async () => {
+  const env = makeEnv({
+    validateCatalog: true,
+    seedLoops: publishedSupportLoops(),
+  });
+  const publish = await handleRequest(
+    adminRequest(exampleLoop({ related: ["overnight-docs-sweep"] })),
+    env,
+  );
+  assert.equal(publish.status, 201);
+
+  const detail = await handleRequest(
+    new Request(`${SITE_ORIGIN}/loop-library/loops/database-publishing-loop/`),
+    env,
+  );
+  const detailHtml = await detail.text();
+
+  assert.equal(detail.status, 200);
+  assert.match(detailHtml, /Related loops/);
+  assert.match(
+    detailHtml,
+    /href="\.\.\/overnight-docs-sweep\/">The overnight docs sweep<\/a>/,
+  );
 });
 
 test("renders homepage headers for HEAD by fetching the origin shell with GET", async () => {
@@ -563,6 +732,7 @@ test("generates catalogs, sitemap, and feed from the same record", async () => {
   for (const [path, expected] of [
     ["catalog.json", '"loopCount":1'],
     ["catalog.md", "The database publishing loop"],
+    ["catalog.txt", "The database publishing loop"],
     ["llms.txt", "Published loops: 1."],
     ["sitemap.xml", "/loops/database-publishing-loop/"],
     ["feed.xml", "The database publishing loop"],

--- a/loop-library/worker/test/loop-routes.test.js
+++ b/loop-library/worker/test/loop-routes.test.js
@@ -472,6 +472,53 @@ test("renders the mounted homepage through a here.now proxy", async () => {
   assert.match(await response.text(), /The database publishing loop/);
 });
 
+test("serves a branded fallback homepage when the here.now shell errors", async () => {
+  const env = makeEnv();
+  await handleRequest(adminRequest(exampleLoop()), env);
+  const response = await handleRequest(
+    new Request(`${SITE_ORIGIN}/loop-library/`),
+    env,
+    undefined,
+    {
+      async fetch() {
+        return new Response("upstream is down", { status: 503 });
+      },
+    },
+  );
+  const html = await response.text();
+
+  // Preserves the real failure status instead of masking it as 200.
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
+  // Branded fallback that still lists every loop, not the upstream error body.
+  assert.doesNotMatch(html, /upstream is down/);
+  assert.match(html, /briefly unavailable/);
+  assert.match(html, /The database publishing loop/);
+  assert.match(html, /loops\/database-publishing-loop\//);
+  assert.match(html, /catalog\.json/);
+  assert.match(html, /<meta name="robots" content="noindex"/);
+});
+
+test("serves the fallback homepage when the here.now shell is unreachable", async () => {
+  const env = makeEnv();
+  await handleRequest(adminRequest(exampleLoop()), env);
+  const response = await handleRequest(
+    new Request(`${SITE_ORIGIN}/loop-library/`),
+    env,
+    undefined,
+    {
+      async fetch() {
+        throw new Error("connection refused");
+      },
+    },
+  );
+  const html = await response.text();
+
+  assert.equal(response.status, 502);
+  assert.match(html, /briefly unavailable/);
+  assert.match(html, /The database publishing loop/);
+});
+
 test("normalizes legacy Forward Future domains on every public catalog surface", async () => {
   const env = makeEnv();
   await handleRequest(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Combines the three open, reviewed PRs into one verified integration so they can land together:

- **#90 — Most popular sort**: adds a standalone `Most popular` option to the homepage sort control, bumps the script cache tag to `20260702-popular-sort`, and extends the repository checks.
- **#89 — Harden Loopy harness checks** (@williamclay8): voting session refresh now fails closed (503) when the vote Durable Object binding is absent, catalog-graph failures are exercised through the admin publish/import routes, and README/AGENTS/CI validation commands are kept in sync (including `catalog.txt` and `llms.txt` in the publish checklist).
- **#85 — Branded homepage fallback** (@HMAKT99): when the here.now shell is unreachable or returns 5xx, the Worker serves a branded, `noindex` fallback listing every published loop from its own database while preserving the real failure status (502/503).

Merging this PR marks the three source PRs as merged automatically.

## Verification (on the combined result)

- `node --check loop-library/site/script.js`
- `node loop-library/scripts/check.mjs` — passes
- `npm --prefix loop-library/worker run check` — 52/52 tests pass
- `python3 -m json.tool` on both JSON manifests — valid
- `git diff --check` — clean

## Post-merge

- Republish the site shell so the new `popular-sort` script cache tag takes effect (per #90).
- No Worker secret or proxy manifest changes required; redeploy the Worker to pick up the fallback and fail-closed session behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7de3ca2f-8e36-4536-8cf0-698f7c030f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7de3ca2f-8e36-4536-8cf0-698f7c030f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

