### PR TITLE
Document signals.forwardfuture.ai redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,4 +386,9 @@ Read [AGENTS.md](AGENTS.md) before editing loops or publishing the site. It
 contains the source-of-truth rules for database publishing, generated
 responses, form security, and clean-main deployments.
 
+The legacy `https://signals.forwardfuture.ai/*` host is maintained by the
+redirect-only Vercel project in
+[`infra/signals-forwardfuture-ai-redirect/`](infra/signals-forwardfuture-ai-redirect/).
+It permanently redirects paths to `https://signals.forwardfuture.com/*`.
+
 </details>

--- a/infra/signals-forwardfuture-ai-redirect/README.md
+++ b/infra/signals-forwardfuture-ai-redirect/README.md
@@ -1,0 +1,15 @@
+# signals.forwardfuture.ai redirect
+
+Redirect-only Vercel project for `signals.forwardfuture.ai`.
+
+It permanently redirects every path to the same path on
+`https://signals.forwardfuture.com`.
+
+## Deploy
+
+```bash
+npx vercel deploy --prod --yes --scope forward-future
+```
+
+The Vercel project is `forward-future/signals-forwardfuture-ai-redirect`.
+The DNS record is `signals.forwardfuture.ai A 76.76.21.21` in Vercel DNS.

--- a/infra/signals-forwardfuture-ai-redirect/api/redirect.js
+++ b/infra/signals-forwardfuture-ai-redirect/api/redirect.js
@@ -1,0 +1,9 @@
+export default function handler(request, response) {
+  const incomingUrl = new URL(request.url, `https://${request.headers.host}`);
+  const targetUrl = new URL(incomingUrl.pathname, "https://signals.forwardfuture.com");
+  targetUrl.search = incomingUrl.search;
+
+  response.statusCode = 308;
+  response.setHeader("Location", targetUrl.toString());
+  response.end();
+}

--- a/infra/signals-forwardfuture-ai-redirect/package.json
+++ b/infra/signals-forwardfuture-ai-redirect/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "signals-forwardfuture-ai-redirect",
+  "private": true
+}

--- a/infra/signals-forwardfuture-ai-redirect/vercel.json
+++ b/infra/signals-forwardfuture-ai-redirect/vercel.json
@@ -1,0 +1,8 @@
+{
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/api/redirect"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add source/runbook for the Vercel redirect-only project serving signals.forwardfuture.ai
- document that the legacy .ai host redirects to signals.forwardfuture.com

## Verification
- node --check loop-library/site/script.js
- node loop-library/scripts/check.mjs
- npm --prefix loop-library/worker run check
- python3 -m json.tool loop-library/site/.herenow/data.json >/dev/null
- python3 -m json.tool loop-library/site/.herenow/proxy.json >/dev/null
- python3 -m json.tool loop-library/scripts/seo-geo-query-benchmark.json >/dev/null
- git diff --check
- curl -IL https://signals.forwardfuture.ai/loop-library/?x=1